### PR TITLE
Adding Pythia and CONSEL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ cython_debug/
 **.done
 *.phy
 *.trees
+*.sitelh
 
 # epa-ng
 *.jplace

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,15 @@ cython_debug/
 *.phy
 *.trees
 *.sitelh
+*.ci
+*.pv
+*.rmt
+*.vt
+*.json
+*consel_pv_output
 
 # epa-ng
 *.jplace
+
+# consel
+consel/*

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -219,6 +219,7 @@ rule random_forest_regression:
 	params:
 		stability_measure=["normalised_tii", "rf_radius"],
 		subdirs=get_subdirs(data_folder),
+		data_folder=data_folder,
 	script:
 		"scripts/random_forest_regression.py"
 
@@ -314,7 +315,7 @@ rule write_pruned_and_inferred_trees:
 		touch("{subdir}/benchmarking/benchmark_write_pruned_trees_{seq_id}.txt")
 	script:
 		"scripts/write_pruned_and_inferred_trees.py"
-
+ 
 
 # AU-test to test model fit of full tree to reattached trees
 rule au_test_model_fit:
@@ -323,7 +324,7 @@ rule au_test_model_fit:
 		trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
 		full_model="{subdir}/iqtree-model.txt",
 	output:
-		# "{subdir}/reduced_alignments/{seq_id}/au-test.iqtree",
+		"{subdir}/reduced_alignments/{seq_id}/au-test.iqtree",
 		touch("{subdir}/reduced_alignments/{seq_id}/au_test_model_fit.done"),
 	benchmark:
 		touch("{subdir}/benchmarking/benchmark_au_test_model_fit_{seq_id}.txt"),
@@ -405,75 +406,75 @@ rule plot_au_test_classifier:
 
 rule write_pruned_and_inferred_sitelh_files:
    input:
-       reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
-       trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
-       full_model="{subdir}/iqtree-model.txt",
+	   reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
+	   trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
+	   full_model="{subdir}/iqtree-model.txt",
    output:
 	   touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
    benchmark:
-       touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
+	   touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
    shell:
-       """
-       iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_ -m $(cat {input.full_model}) -n 0 -wsl
-       iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_ -m $(cat {input.full_model}) -n 0 -wsl
-       """
+	   """
+	   iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_ -m $(cat {input.full_model}) -n 0 -wsl
+	   iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_ -m $(cat {input.full_model}) -n 0 -wsl
+	   """
 
 # combine sitelh files of pruned and inferred tree to one file for CONSEL
 rule combine_sitelh_files:
    input:
-       full_tree_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_pruned_reduced_alignment.sitelh",
-       inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_inferred_reduced_alignment.sitelh",
+	   full_tree_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_pruned_reduced_alignment.sitelh",
+	   inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_inferred_reduced_alignment.sitelh",
    output:
-       both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
+	   both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
    params:
-       seq_id=lambda wildcards: wildcards.seq_id
+	   seq_id=lambda wildcards: wildcards.seq_id
    benchmark:
-       touch("{subdir}/benchmarking/benchmark_combine_sitelh_files{seq_id}.txt")
+	   touch("{subdir}/benchmarking/benchmark_combine_sitelh_files{seq_id}.txt")
    script:
-       "scripts/combine_sitelh_files.py"
+	   "scripts/combine_sitelh_files.py"
 
 
 # run CONSEL to test model fit of full tree to reattached trees
 rule consel_comparison:
    input:
-       paup_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
+	   paup_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
    output:
-       touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
+	   touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
    benchmark:
-       touch("{subdir}/benchmarking/benchmark_consel_comparison{seq_id}.txt"),
+	   touch("{subdir}/benchmarking/benchmark_consel_comparison{seq_id}.txt"),
    shell:
-       """
-       {path_to_consel}/makermt --paup {input.paup_file}
-       {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
-       rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
-       """
+	   """
+	   {path_to_consel}/makermt --paup {input.paup_file}
+	   {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
+	   rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
+	   """
 
 
 # run pypythia to calculate difficulty on all MSAs
 rule calculate_msa_difficulty:
-   input:
-        alignment_name="{subdir}/" + input_alignment
-   output:
-        output_file="{subdir}/pythia_difficulty.txt"
-   benchmark:
-       touch("{subdir}/benchmarking/benchmark_calculate_msa_difficulty.txt")
-   shell:
-       """
-       pythia -m {input.alignment_name} -r {path_to_raxml} -o {output.output_file}
-       """
+	input:
+		alignment_name="{subdir}/"+input_alignment
+	output:
+		output_file="{subdir}/pythia_difficulty.txt"
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_calculate_msa_difficulty.txt")
+	shell:
+		"""
+		pythia -m {input.alignment_name} -r {path_to_raxml} -o {output.output_file}
+		"""
 
 
 rule plot_msa_difficulty:
-   input:
-        alignment_name=expand("{subdir}/pythia_difficulty.txt", subdir=get_subdirs(data_folder))
-   output:
-        plot=data_folder+plots_folder+"pythia_difficulty.pdf"
-   benchmark:
-       touch("benchmarking/benchmark_plot_msa_difficulty.txt")
-   shell:
-       """
-       python scripts/plot_difficulties.py {data_folder} {output.plot} {data_folder}/pythia_difficulties.csv
-       """
+	input:
+		alignment_name=expand("{subdir}/pythia_difficulty.txt", subdir=get_subdirs(data_folder))
+	output:
+		plot=data_folder+plots_folder+"pythia_difficulty.pdf"
+	benchmark:
+		touch("benchmarking/benchmark_plot_msa_difficulty.txt")
+	shell:
+		"""
+		python scripts/plot_difficulties.py {data_folder} {output.plot} {data_folder}/pythia_difficulties.csv
+		"""
 
 
 # create single file for each dataset with timing breakdowns for the rules

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -408,29 +408,26 @@ rule plot_au_test_classifier:
 #        full_tree_sitelh="{subdir}/"+input_alignment+".sitelh"
 #        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.sitelh",
 #    output:
-#        both_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.sitelh"
+#        both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
 #    params:
 #        seq_id=lambda wildcards: wildcards.seq_id
 #    benchmark:
 #        touch("{subdir}/benchmarking/benchmark_write_pruned_trees_sitelh_{seq_id}.txt")
-#    shell:
-#        """
-#        cat {full_tree_sitelh} > {output.both_trees_sitelh}
-#        echo "2$(cut -c 2- {input.inferred_trees_sitelh})" >> {output.both_trees_sitelh}
-#        """
+#    script:
+#        "scripts/combine_sitelh_files.py"
 
 
 # run CONSEL to test model fit of full tree to reattached trees
 #rule consel_comparison:
 #    input:
-#        sitelh_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.sitelh"
+#        paup_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
 #    output:
 #        touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
 #    benchmark:
 #        touch("{subdir}/benchmarking/benchmark_consel_test_model_fit_{seq_id}.txt"),
 #    shell:
 #        """
-#        {path_to_consel}/makermt --puzzle {input.reduced_msa_sl}
+#        {path_to_consel}/makermt --paup {input.paup_file}
 #        {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
 #        """
 

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -13,6 +13,7 @@ data_folder=config["data_folder"]+"/selected_data/"
 plots_folder="plots/"
 IQTREE_SUFFIXES=["iqtree", "log", "treefile", "ckp.gz"]
 path_to_consel=config["path_to_consel"]
+path_to_raxml=config["path_to_raxml"]
 
 
 def get_subdirs(data_folder):
@@ -401,38 +402,23 @@ rule plot_au_test_classifier:
     script:
         "scripts/plot_au_test_classifier.py"
 
-
-#rule write_full_sitelh:
-#    input:
-#        full_msa="{subdir}/"+input_alignment,
-#        trees="{subdir}/"+input_alignment+".treefile",
-#        full_model="{subdir}/iqtree-model.txt",
-#    output:
-#        touch("{subdir}/write_full_sitelh.done"),
-#    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_write_full_sitelh.txt"),
-#    shell:
-#        """
-#        iqtree -s {input.full_msa} -z {input.trees} --prefix {wildcards.subdir}/consel- -m $(cat {input.full_model}) -n 0 -wsl -redo
-#        """
-
-
-#rule write_inferred_sitelh:
+#rule write_pruned_and_inferred_sitelh_files:
 #    input:
 #        reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
-#        trees="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+#        trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
 #        full_model="{subdir}/iqtree-model.txt",
 #    output:
 #        touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
 #    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_write_inferred_sitelh{seq_id}.txt"),
+#        touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
 #    shell:
 #        """
-#        iqtree -s {input.reduced_msa} -z {input.trees} --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel- -m $(cat {input.full_model}) -n 0 -wsl -redo
+#        iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel- -m $(cat {input.full_model}) -n 0 -wsl
+#        iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel- -m $(cat {input.full_model}) -n 0 -wsl
 #        """
 
 # combine sitelh files of pruned and inferred tree to one file for CONSEL
-#rule write_pruned_and_inferred_sitelh_files:
+#rule combine_sitelh_files:
 #    input:
 #        full_tree_sitelh="{subdir}/consel-"+input_alignment+".sitelh"
 #        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel-reduced_alignment.sitelh",
@@ -441,7 +427,7 @@ rule plot_au_test_classifier:
 #    params:
 #        seq_id=lambda wildcards: wildcards.seq_id
 #    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_write_pruned_trees_sitelh_{seq_id}.txt")
+#        touch("{subdir}/benchmarking/benchmark_combine_sitelh_files{seq_id}.txt")
 #    script:
 #        "scripts/combine_sitelh_files.py"
 
@@ -453,12 +439,26 @@ rule plot_au_test_classifier:
 #    output:
 #        touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
 #    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_consel_test_model_fit_{seq_id}.txt"),
+#        touch("{subdir}/benchmarking/benchmark_consel_comparison{seq_id}.txt"),
 #    shell:
 #        """
 #        {path_to_consel}/makermt --paup {input.paup_file}
 #        {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
 #        rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
+#        """
+
+
+# run pypythia to calculate difficulty on all MSAs
+#rule calculate_msa_difficulty:
+#    input:
+#         alignment_name="{subdir}/" + input_alignment
+#    output:
+#         output_file="{subdir}/pythia_difficulty.txt"
+#    benchmark:
+#        touch("{subdir}/benchmarking/benchmark_calculate_msa_difficulty.txt")
+#    shell:
+#        """
+#        pythia -m {input.alignment_name} -r {path_to_raxml} -o {output.output_file}/pythia_difficulty.txt
 #        """
 
 # create single file for each dataset with timing breakdowns for the rules

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -12,6 +12,7 @@ input_alignment="full_alignment.fasta"
 data_folder=config["data_folder"]+"/selected_data/"
 plots_folder="plots/"
 IQTREE_SUFFIXES=["iqtree", "log", "treefile", "ckp.gz"]
+path_to_consel=config["path_to_consel"]
 
 
 def get_subdirs(data_folder):
@@ -104,12 +105,13 @@ rule run_iqtree_on_full_dataset:
     output:
         temp(touch("{subdir}/run_iqtree_on_full_dataset.done")),
         tree="{subdir}/"+input_alignment+".treefile",
-        mldist="{subdir}/"+input_alignment+".mldist"
+        mldist="{subdir}/"+input_alignment+".mldist",
+        sitelh="{subdir}/"+input_alignment+".sitelh"
     benchmark:
         touch("{subdir}/benchmarking/benchmark_run_iqtree_on_full_dataset.txt")
     shell:
         """
-        iqtree -s {input.msa} -m $(cat {input.full_model}) --prefix {input.msa} -bb 1000 -redo
+        iqtree -s {input.msa} -m $(cat {input.full_model}) -wsl --prefix {input.msa} -bb 1000 -redo
         """
 
 
@@ -123,12 +125,13 @@ rule run_iqtree_restricted_alignments:
         done=temp(touch("{subdir}/reduced_alignments/{seq_id}/run_iqtree_restricted_alignments.done")),
         tree="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
         mlfile="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.iqtree",
-        mldist="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.mldist"
+        mldist="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.mldist",
+        sitelh="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.sitelh"
     benchmark:
         touch("{subdir}/benchmarking/benchmark_run_iqtree_restricted_alignments_{seq_id}.txt")
     shell:
         """
-        iqtree -s {input.reduced_msa} -m $(cat {input.full_model}) --prefix {input.reduced_msa} -bb 1000 -redo
+        iqtree -s {input.reduced_msa} -m $(cat {input.full_model}) -wsl --prefix {input.reduced_msa} -bb 1000 -redo
         """
 
 
@@ -398,6 +401,38 @@ rule plot_au_test_classifier:
     script:
         "scripts/plot_au_test_classifier.py"
 
+
+# combine sitelh files of pruned and inferred tree to one file for CONSEL
+#rule write_pruned_and_inferred_sitelh_files:
+#    input:
+#        full_tree_sitelh="{subdir}/"+input_alignment+".sitelh"
+#        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.sitelh",
+#    output:
+#        both_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.sitelh"
+#    params:
+#        seq_id=lambda wildcards: wildcards.seq_id
+#    benchmark:
+#        touch("{subdir}/benchmarking/benchmark_write_pruned_trees_sitelh_{seq_id}.txt")
+#    shell:
+#        """
+#        cat {full_tree_sitelh} > {output.both_trees_sitelh}
+#        echo "2$(cut -c 2- {input.inferred_trees_sitelh})" >> {output.both_trees_sitelh}
+#        """
+
+
+# run CONSEL to test model fit of full tree to reattached trees
+#rule consel_comparison:
+#    input:
+#        sitelh_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.sitelh"
+#    output:
+#        touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
+#    benchmark:
+#        touch("{subdir}/benchmarking/benchmark_consel_test_model_fit_{seq_id}.txt"),
+#    shell:
+#        """
+#        {path_to_consel}/makermt --puzzle {input.reduced_msa_sl}
+#        {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
+#        """
 
 # create single file for each dataset with timing breakdowns for the rules
 rule combine_benchmark_outputs:

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -373,6 +373,7 @@ rule analyse_au_test:
 rule au_test_classifier:
 	input:
 		"all_consel_test_done.done",
+		data_folder+"au_test_result_with_consel_pv.csv",
 		combined_statistics=data_folder+"rf_regression_combined_statistics.csv",
 	params:
 		column_to_predict = "significant_unstable",
@@ -397,27 +398,55 @@ rule au_test_classifier:
 rule plot_au_test_classifier:
 	input:
 		data_folder+"au_test_classifier.done",
-		all_au_test_results=data_folder+"au_test_result.csv",
+		all_au_test_results=data_folder+"au_test_result_with_consel_pv.csv",
 	output:
 		touch("plot_au_test_classifier.done"),
 		pie_plot_file=data_folder+plots_folder+"au_pie_chart.pdf",
 	script:
 		"scripts/plot_au_test_classifier.py"
 
-rule write_pruned_and_inferred_sitelh_files:
+
+rule write_pruned_tree:
+	input:
+		trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
+	output:
+		pruned_tree="{subdir}/reduced_alignments/{seq_id}/pruned_tree.nwk"
+	shell:
+		"""
+		echo $(head -1 {input.trees}) > {output.pruned_tree}
+		"""
+
+
+rule write_pruned_sitelh_files:
    input:
 	   reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
-	   trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
+	   pruned_tree="{subdir}/reduced_alignments/{seq_id}/pruned_tree.nwk",
 	   full_model="{subdir}/iqtree-model.txt",
    output:
-	   touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
+	   touch("{subdir}/reduced_alignments/{seq_id}/write_pruned_sitelh.done"),
+	   full_tree_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_pruned_reduced_alignment.sitelh",
    benchmark:
-	   touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
+	   touch("{subdir}/benchmarking/benchmark_write_pruned_sitelh_files{seq_id}.txt"),
    shell:
 	   """
-	   iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_ -m $(cat {input.full_model}) -n 0 -wsl
-	   iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_ -m $(cat {input.full_model}) -n 0 -wsl
+	   iqtree -s {input.reduced_msa} -z {input.pruned_tree} --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_reduced_alignment -m $(cat {input.full_model}) -n 0 -wsl
 	   """
+
+
+rule write_inferred_sitelh_files:
+	input:
+		reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
+		inferred_tree="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+		full_model="{subdir}/iqtree-model.txt",
+	output:
+		touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
+		inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_inferred_reduced_alignment.sitelh",
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_write_inferred_sitelh_files{seq_id}.txt"),
+	shell:
+		"""
+		iqtree -s {input.reduced_msa} -z {input.inferred_tree} --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_reduced_alignment -m $(cat {input.full_model}) -n 0 -wsl
+		"""
 
 # combine sitelh files of pruned and inferred tree to one file for CONSEL
 rule combine_sitelh_files:
@@ -475,13 +504,15 @@ rule add_consel_to_au:
 		"all_consel_test_done.done",
 		au_test_results=data_folder+"au_test_result.csv",
 	output:
-		temp(touch("all_consel_test_done.done")),
+		data_folder+"au_test_result_with_consel_pv.csv",
 	benchmark:
 		touch(data_folder + "benchmarking/benchmark_add_consel_to_au.txt")
 	params:
-		subdirs=subdirs
-	script:
-		"scripts/compare_au_outputs.py {data_folder} {input.au_test_results} {path_to_consel}"
+		data_folder=data_folder
+	shell:
+		"""
+		python scripts/compare_au_outputs.py {params.data_folder} {input.au_test_results} {path_to_consel}
+		"""
 
 
 # run pypythia to calculate difficulty on all MSAs

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -17,472 +17,487 @@ path_to_raxml=config["path_to_raxml"]
 
 
 def get_subdirs(data_folder):
-    return [
-        f.path for f in os.scandir(data_folder) if f.is_dir()
-        and "plot" not in f.path
-        and "benchmarking" not in f.path
-        and "rf_radius" not in f.path
-        and "normalised_tii" not in f.path
-        and "unbalanced_no_non_taxon" not in f.path
-    ]
+	return [
+		f.path for f in os.scandir(data_folder) if f.is_dir()
+		and "plot" not in f.path
+		and "benchmarking" not in f.path
+		and "rf_radius" not in f.path
+		and "normalised_tii" not in f.path
+		and "unbalanced_no_non_taxon" not in f.path
+	]
 
 
 subdirs = get_subdirs(data_folder)
 for subdir in subdirs:
-    if not os.path.exists(subdir + "/benchmarking"):
-        os.makedirs(subdir + "/benchmarking")
+	if not os.path.exists(subdir + "/benchmarking"):
+		os.makedirs(subdir + "/benchmarking")
 
 # Retrieve all sequence IDs from the input multiple sequence alignment
 def get_seq_ids(input_file, filetype):
-    return [record.id for record in SeqIO.parse(input_file, filetype)]
+	return [record.id for record in SeqIO.parse(input_file, filetype)]
 
 
 def dynamic_input(wildcards):
-    subdir = wildcards.subdir
-    fasta_files = glob.glob(os.path.join(subdir, "*.fasta"))
-    fasta_files = [os.readlink(file) if os.path.islink(file) else file for file in fasta_files]
-    seq_ids = get_seq_ids(fasta_files[0], "fasta")
+	subdir = wildcards.subdir
+	fasta_files = glob.glob(os.path.join(subdir, "*.fasta"))
+	fasta_files = [os.readlink(file) if os.path.islink(file) else file for file in fasta_files]
+	seq_ids = get_seq_ids(fasta_files[0], "fasta")
 
-    epa_results = [subdir+"/reduced_alignments/"+seq_id+"/epa_result.jplace" for seq_id in seq_ids]
-    restricted_trees = [subdir+"/reduced_alignments/"+seq_id+"/reduced_alignment.fasta.treefile" for seq_id in seq_ids]
-    restricted_mldist_files = [subdir+"/reduced_alignments/"+seq_id+"/reduced_alignment.fasta.mldist" for seq_id in seq_ids]
-    reattached_trees = [subdir+"/reduced_alignments/"+seq_id+"/reattached_tree.nwk" for seq_id in seq_ids]
-    return epa_results + restricted_trees + restricted_mldist_files + reattached_trees
+	epa_results = [subdir+"/reduced_alignments/"+seq_id+"/epa_result.jplace" for seq_id in seq_ids]
+	restricted_trees = [subdir+"/reduced_alignments/"+seq_id+"/reduced_alignment.fasta.treefile" for seq_id in seq_ids]
+	restricted_mldist_files = [subdir+"/reduced_alignments/"+seq_id+"/reduced_alignment.fasta.mldist" for seq_id in seq_ids]
+	reattached_trees = [subdir+"/reduced_alignments/"+seq_id+"/reattached_tree.nwk" for seq_id in seq_ids]
+	return epa_results + restricted_trees + restricted_mldist_files + reattached_trees
 
 
 # Define the workflow
 rule all:
-    input:
-        "random_forest_plots.done",
-        # "benchmarking_plots.done",
-        "plot_au_test_classifier.done",
+	input:
+		"random_forest_plots.done",
+		# "benchmarking_plots.done",
+		"plot_au_test_classifier.done",
+		data_folder+plots_folder+"pythia_difficulty.pdf"
 
 
 # Define the rule to extract the best model for iqtree on the full MSA
 rule model_test_iqtree:
-    input:
-        msa="{subdir}/"+input_alignment
-    output:
-        temp(touch("{subdir}/model-test-iqtree.done")),
-        modeltest="{subdir}/"+input_alignment+"_model.iqtree"
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_model_test_iqtree.txt")
-    shell:
-        """
-        iqtree -s {input.msa} --prefix {input.msa}_model -m MF -redo
-        """
+	input:
+		msa="{subdir}/"+input_alignment
+	output:
+		temp(touch("{subdir}/model-test-iqtree.done")),
+		modeltest="{subdir}/"+input_alignment+"_model.iqtree"
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_model_test_iqtree.txt")
+	shell:
+		"""
+		iqtree -s {input.msa} --prefix {input.msa}_model -m MF -redo
+		"""
 
 
 # Define the rule to extract the model from the IQ-TREE run on the full msa
 rule extract_model_for_full_iqtree_run:
-    input:
-        "{subdir}/model-test-iqtree.done",
-        iqtree=rules.model_test_iqtree.output.modeltest,
-    output:
-        model="{subdir}/iqtree-model.txt"
-    script:
-        "scripts/extract_model.py"
+	input:
+		"{subdir}/model-test-iqtree.done",
+		iqtree=rules.model_test_iqtree.output.modeltest,
+	output:
+		model="{subdir}/iqtree-model.txt"
+	script:
+		"scripts/extract_model.py"
 
 
 # Define the rule to remove a sequence from the MSA and write the reduced MSA to a file
 rule remove_sequence:
-    input:
-        msa="{subdir}/"+input_alignment
-    output:
-        reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_remove_sequence_{seq_id}.txt")
-    params:
-        seq_id=lambda wildcards: wildcards.seq_id
-    script:
-        "scripts/remove_sequence.py"
+	input:
+		msa="{subdir}/"+input_alignment
+	output:
+		reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_remove_sequence_{seq_id}.txt")
+	params:
+		seq_id=lambda wildcards: wildcards.seq_id
+	script:
+		"scripts/remove_sequence.py"
 
 
 # Define the rule to run IQ-TREE on the full MSA and get model parameters
 rule run_iqtree_on_full_dataset:
-    input:
-        msa="{subdir}/"+input_alignment,
-        full_model="{subdir}/iqtree-model.txt"
-    output:
-        temp(touch("{subdir}/run_iqtree_on_full_dataset.done")),
-        tree="{subdir}/"+input_alignment+".treefile",
-        mldist="{subdir}/"+input_alignment+".mldist",
-        sitelh="{subdir}/"+input_alignment+".sitelh"
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_run_iqtree_on_full_dataset.txt")
-    shell:
-        """
-        iqtree -s {input.msa} -m $(cat {input.full_model}) --prefix {input.msa} -bb 1000 -redo
-        """
+	input:
+		msa="{subdir}/"+input_alignment,
+		full_model="{subdir}/iqtree-model.txt"
+	output:
+		temp(touch("{subdir}/run_iqtree_on_full_dataset.done")),
+		tree="{subdir}/"+input_alignment+".treefile",
+		mldist="{subdir}/"+input_alignment+".mldist",
+		sitelh="{subdir}/"+input_alignment+".sitelh"
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_run_iqtree_on_full_dataset.txt")
+	shell:
+		"""
+		iqtree -s {input.msa} -m $(cat {input.full_model}) --prefix {input.msa} -bb 1000 -redo -wsl
+		"""
 
 
 
 # Define the rule to run IQ-TREE on the reduced MSA
 rule run_iqtree_restricted_alignments:
-    input:
-        reduced_msa=rules.remove_sequence.output.reduced_msa,
-        full_model=rules.extract_model_for_full_iqtree_run.output.model,
-    output:
-        done=temp(touch("{subdir}/reduced_alignments/{seq_id}/run_iqtree_restricted_alignments.done")),
-        tree="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
-        mlfile="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.iqtree",
-        mldist="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.mldist",
-        sitelh="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.sitelh"
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_run_iqtree_restricted_alignments_{seq_id}.txt")
-    shell:
-        """
-        iqtree -s {input.reduced_msa} -m $(cat {input.full_model}) --prefix {input.reduced_msa} -bb 1000 -redo
-        """
+	input:
+		reduced_msa=rules.remove_sequence.output.reduced_msa,
+		full_model=rules.extract_model_for_full_iqtree_run.output.model,
+	output:
+		done=temp(touch("{subdir}/reduced_alignments/{seq_id}/run_iqtree_restricted_alignments.done")),
+		tree="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+		mlfile="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.iqtree",
+		mldist="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.mldist",
+		sitelh="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.sitelh"
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_run_iqtree_restricted_alignments_{seq_id}.txt")
+	shell:
+		"""
+		iqtree -s {input.reduced_msa} -m $(cat {input.full_model}) --prefix {input.reduced_msa} -bb 1000 -redo -wsl
+		"""
 
 
 # Extract fastas containing single sequences for epa-ng insertion
 rule extract_single_fastas:
-    input:
-        msa="{subdir}/"+input_alignment
-    output:
-        taxon_msa="{subdir}/reduced_alignments/{seq_id}/single_taxon.fasta",
-        without_taxon_msa="{subdir}/reduced_alignments/{seq_id}/without_taxon.fasta"
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_extract_single_fastas_{seq_id}.txt")
-    params:
-        seq_id=lambda wildcards: wildcards.seq_id
-    script:
-        "scripts/extract_single_taxon_msa.py"
+	input:
+		msa="{subdir}/"+input_alignment
+	output:
+		taxon_msa="{subdir}/reduced_alignments/{seq_id}/single_taxon.fasta",
+		without_taxon_msa="{subdir}/reduced_alignments/{seq_id}/without_taxon.fasta"
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_extract_single_fastas_{seq_id}.txt")
+	params:
+		seq_id=lambda wildcards: wildcards.seq_id
+	script:
+		"scripts/extract_single_taxon_msa.py"
 
 
 # Compute best insertion locations for taxon with epa-ng
 rule epa_reattachment:
-    input:
-        rules.run_iqtree_restricted_alignments.output.done,
-        tree="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
-        model=rules.extract_model_for_full_iqtree_run.output.model,
-        taxon_msa="{subdir}/reduced_alignments/{seq_id}/single_taxon.fasta",
-        without_taxon_msa="{subdir}/reduced_alignments/{seq_id}/without_taxon.fasta",
-    output:
-        epa_result="{subdir}/reduced_alignments/{seq_id}/epa_result.jplace",
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_epa_reattachment_{seq_id}.txt")
-    params:
-        output_folder="{subdir}/reduced_alignments/{seq_id}"
-    shell:
-        """
-        model=$(cat {input.model})
-        epa-ng --ref-msa {input.without_taxon_msa} --tree {input.tree} --query {input.taxon_msa} --model $model -w {params.output_folder} --redo
-        """
+	input:
+		rules.run_iqtree_restricted_alignments.output.done,
+		tree="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+		model=rules.extract_model_for_full_iqtree_run.output.model,
+		taxon_msa="{subdir}/reduced_alignments/{seq_id}/single_taxon.fasta",
+		without_taxon_msa="{subdir}/reduced_alignments/{seq_id}/without_taxon.fasta",
+	output:
+		epa_result="{subdir}/reduced_alignments/{seq_id}/epa_result.jplace",
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_epa_reattachment_{seq_id}.txt")
+	params:
+		output_folder="{subdir}/reduced_alignments/{seq_id}"
+	shell:
+		"""
+		model=$(cat {input.model})
+		epa-ng --ref-msa {input.without_taxon_msa} --tree {input.tree} --query {input.taxon_msa} --model $model -w {params.output_folder} --redo
+		"""
 
 
 # convert epa-ng output to actual trees
 rule write_reattached_trees:
-    input:
-        epa_result="{subdir}/reduced_alignments/{seq_id}/epa_result.jplace",
-        restricted_trees="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
-    output:
-        reattached_trees="{subdir}/reduced_alignments/{seq_id}/reattached_tree.nwk",
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_write_reattached_trees_{seq_id}.txt")
-    script:
-        "scripts/write_reattached_trees.py"
+	input:
+		epa_result="{subdir}/reduced_alignments/{seq_id}/epa_result.jplace",
+		restricted_trees="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+	output:
+		reattached_trees="{subdir}/reduced_alignments/{seq_id}/reattached_tree.nwk",
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_write_reattached_trees_{seq_id}.txt")
+	script:
+		"scripts/write_reattached_trees.py"
 
 
 # compute all summary statistics as input for random forest predictions
 rule extract_reattachment_statistics:
-    input:
-        dynamic_input=dynamic_input,
-        full_tree="{subdir}/"+input_alignment+".treefile",
-        full_mldist_file="{subdir}/"+input_alignment+".mldist",
-    output:
-        plot_csv="{subdir}/reduced_alignments/reattachment_data_per_taxon_epa.csv",
-        random_forest_csv="{subdir}/reduced_alignments/random_forest_input.csv",
-        bootstrap_csv="{subdir}/reduced_alignments/bts_bootstrap.csv",
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_extract_reattachment_statistics.txt")
-    script:
-        "scripts/extract_reattachment_statistics.py"
+	input:
+		dynamic_input=dynamic_input,
+		full_tree="{subdir}/"+input_alignment+".treefile",
+		full_mldist_file="{subdir}/"+input_alignment+".mldist",
+	output:
+		plot_csv="{subdir}/reduced_alignments/reattachment_data_per_taxon_epa.csv",
+		random_forest_csv="{subdir}/reduced_alignments/random_forest_input.csv",
+		bootstrap_csv="{subdir}/reduced_alignments/bts_bootstrap.csv",
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_extract_reattachment_statistics.txt")
+	script:
+		"scripts/extract_reattachment_statistics.py"
 
 
 # regression predicting stability measure
 rule random_forest_regression:
-    input:
-        csvs=expand("{subdir}/reduced_alignments/random_forest_input.csv", subdir=get_subdirs(data_folder)),
-    output:
-        model_features_file=expand(data_folder+"{stability_measure}/regression_model_feature_importances.csv", stability_measure=["normalised_tii", "rf_radius"]),
-        output_file_name=expand(data_folder+"{stability_measure}/random_forest_regression.csv", stability_measure=["normalised_tii", "rf_radius"]),
-        combined_csv_path=data_folder+"rf_regression_combined_statistics.csv",
-        parameter_file=expand(data_folder+"{stability_measure}/best_parameters_regression.json", stability_measure=["normalised_tii", "rf_radius"]),
-        r2_file=expand(data_folder+"{stability_measure}/regression_r2.txt", stability_measure=["normalised_tii", "rf_radius"]),
-        regression_bins=expand(data_folder+"{stability_measure}/regression_bins.csv", stability_measure=["normalised_tii", "rf_radius"]),
-        rf_regression_balanced_input=expand(data_folder+"{stability_measure}/rf_regression_balanced_input.csv", stability_measure=["normalised_tii", "rf_radius"]),
-    # benchmark:
-    #     touch(data_folder + "benchmarking/benchmark_random_forest_regression.txt")
-    params:
-        stability_measure=["normalised_tii", "rf_radius"],
-        subdirs=get_subdirs(data_folder),
-    script:
-        "scripts/random_forest_regression.py"
+	input:
+		csvs=expand("{subdir}/reduced_alignments/random_forest_input.csv", subdir=get_subdirs(data_folder)),
+	output:
+		model_features_file=expand(data_folder+"{stability_measure}/regression_model_feature_importances.csv", stability_measure=["normalised_tii", "rf_radius"]),
+		output_file_name=expand(data_folder+"{stability_measure}/random_forest_regression.csv", stability_measure=["normalised_tii", "rf_radius"]),
+		combined_csv_path=data_folder+"rf_regression_combined_statistics.csv",
+		parameter_file=expand(data_folder+"{stability_measure}/best_parameters_regression.json", stability_measure=["normalised_tii", "rf_radius"]),
+		r2_file=expand(data_folder+"{stability_measure}/regression_r2.txt", stability_measure=["normalised_tii", "rf_radius"]),
+		regression_bins=expand(data_folder+"{stability_measure}/regression_bins.csv", stability_measure=["normalised_tii", "rf_radius"]),
+		rf_regression_balanced_input=expand(data_folder+"{stability_measure}/rf_regression_balanced_input.csv", stability_measure=["normalised_tii", "rf_radius"]),
+	# benchmark:
+	#     touch(data_folder + "benchmarking/benchmark_random_forest_regression.txt")
+	params:
+		stability_measure=["normalised_tii", "rf_radius"],
+		subdirs=get_subdirs(data_folder),
+	script:
+		"scripts/random_forest_regression.py"
 
 
 # classification predicting stability measure
 rule random_forest_classification:
-    input:
-        combined_csv_path=data_folder+"rf_regression_combined_statistics.csv",
-    output:
-        model_features_file=data_folder+"classifier_model_feature_importances.csv",
-        output_file_name=data_folder+"random_forest_classification.csv",
-        classifier_metrics_csv=data_folder+"classifier_results.csv",
-        parameter_file=data_folder+"best_parameters_classifier.json",
-    benchmark:
-        touch(data_folder + "benchmarking/benchmark_random_forest_classifier.txt")
-    params:
-        data_folder=data_folder,
-        column_to_predict = "tii",
-        subdirs=get_subdirs(data_folder)
-    run:
-        from scripts.random_forest_classifier import random_forest_classification
-        try: 
-            random_forest_classification(params.column_to_predict, input.combined_csv_path,
-            output.output_file_name, output.model_features_file, output.classifier_metrics_csv,
-            output.parameter_file, params.data_folder)
-        except ValueError as e:
-            print(e)
+	input:
+		combined_csv_path=data_folder+"rf_regression_combined_statistics.csv",
+	output:
+		model_features_file=data_folder+"classifier_model_feature_importances.csv",
+		output_file_name=data_folder+"random_forest_classification.csv",
+		classifier_metrics_csv=data_folder+"classifier_results.csv",
+		parameter_file=data_folder+"best_parameters_classifier.json",
+	benchmark:
+		touch(data_folder + "benchmarking/benchmark_random_forest_classifier.txt")
+	params:
+		data_folder=data_folder,
+		column_to_predict = "tii",
+		subdirs=get_subdirs(data_folder)
+	run:
+		from scripts.random_forest_classifier import random_forest_classification
+		try: 
+			random_forest_classification(params.column_to_predict, input.combined_csv_path,
+			output.output_file_name, output.model_features_file, output.classifier_metrics_csv,
+			output.parameter_file, params.data_folder)
+		except ValueError as e:
+			print(e)
 
 
 # plot random forest results as well as stability measures
 rule random_forest_plots:
-    input:
-        random_forest_csv=rules.random_forest_regression.output.output_file_name,
-        model_features_csv=rules.random_forest_regression.output.model_features_file,
-        random_forest_classifier_csv=rules.random_forest_classification.output.output_file_name,
-        discrete_model_features_csv=rules.random_forest_classification.output.model_features_file,
-        classifier_metrics_csv=rules.random_forest_classification.output.classifier_metrics_csv,
-        combined_csv_path=data_folder+"rf_regression_combined_statistics.csv",
-        r2_file=rules.random_forest_regression.output.r2_file,
-        au_test_classifier_metrics_csv=data_folder+"au_test_classifier_results.csv",
-        au_test_classifier_results=data_folder+"au_test_classification.csv",
-        au_test_model_features_file=data_folder+"au_test_feature_importances.csv",
-    benchmark:
-        touch(data_folder + "benchmarking/benchmark_random_forest_plots.txt")
-    params:
-        forest_plot_folder=data_folder+"plots/",
-        stability_measure=["normalised_tii", "rf_radius"]
-    output:
-        temp(touch("random_forest_plots.done"))
-    script:
-        "scripts/random_forest_plots.py"
+	input:
+		random_forest_csv=rules.random_forest_regression.output.output_file_name,
+		model_features_csv=rules.random_forest_regression.output.model_features_file,
+		random_forest_classifier_csv=rules.random_forest_classification.output.output_file_name,
+		discrete_model_features_csv=rules.random_forest_classification.output.model_features_file,
+		classifier_metrics_csv=rules.random_forest_classification.output.classifier_metrics_csv,
+		combined_csv_path=data_folder+"rf_regression_combined_statistics.csv",
+		r2_file=rules.random_forest_regression.output.r2_file,
+		au_test_classifier_metrics_csv=data_folder+"au_test_classifier_results.csv",
+		au_test_classifier_results=data_folder+"au_test_classification.csv",
+		au_test_model_features_file=data_folder+"au_test_feature_importances.csv",
+	benchmark:
+		touch(data_folder + "benchmarking/benchmark_random_forest_plots.txt")
+	params:
+		forest_plot_folder=data_folder+"plots/",
+		stability_measure=["normalised_tii", "rf_radius"]
+	output:
+		touch("random_forest_plots.done")
+	script:
+		"scripts/random_forest_plots.py"
 
 
 # create plots for statistics of each dataset
 rule create_plots:
-    input:
-        csv="{subdir}/reduced_alignments/reattachment_data_per_taxon_epa.csv",
-        bootstrap_csv="{subdir}/reduced_alignments/bts_bootstrap.csv",
-    output:
-        temp(touch("{subdir}/create_plots.done")),
-    params:
-        plots_folder="{subdir}/"+plots_folder,
-    script:
-        "scripts/create_plots.py"
+	input:
+		csv="{subdir}/reduced_alignments/reattachment_data_per_taxon_epa.csv",
+		bootstrap_csv="{subdir}/reduced_alignments/bts_bootstrap.csv",
+	output:
+		temp(touch("{subdir}/create_plots.done")),
+	params:
+		plots_folder="{subdir}/"+plots_folder,
+	script:
+		"scripts/create_plots.py"
 
 
 # create additional plots for statistics of each dataset
 rule create_other_plots:
-    input:
-        dynamic_input=dynamic_input,
-        csv="{subdir}/reduced_alignments/reattachment_data_per_taxon_epa.csv",
-        full_tree="{subdir}/"+input_alignment+".treefile",
-        mldist="{subdir}/"+input_alignment+".mldist",
-    output:
-        temp(touch("{subdir}/create_other_plots.done")),
-    params:
-        plots_folder="{subdir}/"+plots_folder,
-        subdir=lambda wildcards: wildcards.subdir,
-    script:
-        "scripts/create_other_plots.py"
+	input:
+		dynamic_input=dynamic_input,
+		csv="{subdir}/reduced_alignments/reattachment_data_per_taxon_epa.csv",
+		full_tree="{subdir}/"+input_alignment+".treefile",
+		mldist="{subdir}/"+input_alignment+".mldist",
+	output:
+		temp(touch("{subdir}/create_other_plots.done")),
+	params:
+		plots_folder="{subdir}/"+plots_folder,
+		subdir=lambda wildcards: wildcards.subdir,
+	script:
+		"scripts/create_other_plots.py"
 
 
 # combine newick of pruned and inferred tree to one file for AU-test
 rule write_pruned_and_inferred_trees:
-    input:
-        full_tree="{subdir}/"+input_alignment+".treefile",
-        inferred_trees="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
-    output:
-        both_trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
-    params:
-        seq_id=lambda wildcards: wildcards.seq_id
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_write_pruned_trees_{seq_id}.txt")
-    script:
-        "scripts/write_pruned_and_inferred_trees.py"
+	input:
+		full_tree="{subdir}/"+input_alignment+".treefile",
+		inferred_trees="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+	output:
+		both_trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
+	params:
+		seq_id=lambda wildcards: wildcards.seq_id
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_write_pruned_trees_{seq_id}.txt")
+	script:
+		"scripts/write_pruned_and_inferred_trees.py"
 
 
 # AU-test to test model fit of full tree to reattached trees
 rule au_test_model_fit:
-    input:
-        reduced_msa_au="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
-        trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
-        full_model="{subdir}/iqtree-model.txt",
-    output:
-        # "{subdir}/reduced_alignments/{seq_id}/au-test.iqtree",
-        touch("{subdir}/reduced_alignments/{seq_id}/au_test_model_fit.done"),
-    benchmark:
-        touch("{subdir}/benchmarking/benchmark_au_test_model_fit_{seq_id}.txt"),
-    shell:
-        """
-        iqtree -s {input.reduced_msa_au} -z {input.trees} --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/au-test -m $(cat {input.full_model}) -n 0 -zb 10000 -zw -au -redo
-        """
+	input:
+		reduced_msa_au="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
+		trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
+		full_model="{subdir}/iqtree-model.txt",
+	output:
+		# "{subdir}/reduced_alignments/{seq_id}/au-test.iqtree",
+		touch("{subdir}/reduced_alignments/{seq_id}/au_test_model_fit.done"),
+	benchmark:
+		touch("{subdir}/benchmarking/benchmark_au_test_model_fit_{seq_id}.txt"),
+	shell:
+		"""
+		iqtree -s {input.reduced_msa_au} -z {input.trees} --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/au-test -m $(cat {input.full_model}) -n 0 -zb 10000 -zw -au -redo
+		"""
 
 
 # auxiliary function to check that all AU-tests are done
 def aggregate_all_au_done(wildcards):
-    all_done = []
-    for subdir in subdirs:
-        fasta_files = glob.glob(os.path.join(subdir, "*.fasta"))
-        fasta_files = [os.readlink(file) if os.path.islink(file) else file for file in fasta_files]
-        seq_ids = get_seq_ids(fasta_files[0], "fasta")
-        for seq_id in seq_ids:
-            all_done.append(subdir+"/reduced_alignments/"+seq_id+"/au_test_model_fit.done")
-    return all_done
+	all_done = []
+	for subdir in subdirs:
+		fasta_files = glob.glob(os.path.join(subdir, "*.fasta"))
+		fasta_files = [os.readlink(file) if os.path.islink(file) else file for file in fasta_files]
+		seq_ids = get_seq_ids(fasta_files[0], "fasta")
+		for seq_id in seq_ids:
+			all_done.append(subdir+"/reduced_alignments/"+seq_id+"/au_test_model_fit.done")
+	return all_done
 
 
 # rule that detects if all au test are done to then run rule analyse_au_test
 rule all_au_test_done_subset:
-    input:
-        aggregate_all_au_done
-    output:
-        touch("all_au_test_done.done")
+	input:
+		aggregate_all_au_done
+	output:
+		touch("all_au_test_done.done")
 
 
 # aggregate output of AU test and transform it to csv for classifier and plotting
 rule analyse_au_test:
-    input:
-        "all_au_test_done.done",
-    output:
-        temp(touch("analyse_au_test.done")),
-        au_test_results=data_folder+"au_test_result.csv",
-    benchmark:
-        touch(data_folder + "benchmarking/benchmark_analyse_au_test.txt")
-    params:
-        subdirs=subdirs
-    script:
-        "scripts/analyse_au_test.py"
+	input:
+		"all_au_test_done.done",
+	output:
+		temp(touch("analyse_au_test.done")),
+		au_test_results=data_folder+"au_test_result.csv",
+	benchmark:
+		touch(data_folder + "benchmarking/benchmark_analyse_au_test.txt")
+	params:
+		subdirs=subdirs
+	script:
+		"scripts/analyse_au_test.py"
 
 
 # random forest classification for significant instability
 rule au_test_classifier:
-    input:
-        "analyse_au_test.done",
-        combined_statistics=data_folder+"rf_regression_combined_statistics.csv",
-    params:
-        column_to_predict = "significant_unstable",
-        data_folder=data_folder,
-        parameter_file=data_folder+"best_parameters_au_test_classifier.json",
-    output:
-        temp(touch(data_folder+"au_test_classifier.done")),
-        model_features_file=data_folder+"au_test_feature_importances.csv",
-        classifier_metrics_csv=data_folder+"au_test_classifier_results.csv",
-        output_file_name=data_folder+"au_test_classification.csv",
-    run:
-        from scripts.random_forest_classifier import random_forest_classification
-        try:
-            random_forest_classification(params.column_to_predict, input.combined_statistics,
-            output.output_file_name, output.model_features_file, output.classifier_metrics_csv,
-            params.parameter_file, params.data_folder)
-        except ValueError as e:
-            print(e)
+	input:
+		"analyse_au_test.done",
+		combined_statistics=data_folder+"rf_regression_combined_statistics.csv",
+	params:
+		column_to_predict = "significant_unstable",
+		data_folder=data_folder,
+		parameter_file=data_folder+"best_parameters_au_test_classifier.json",
+	output:
+		temp(touch(data_folder+"au_test_classifier.done")),
+		model_features_file=data_folder+"au_test_feature_importances.csv",
+		classifier_metrics_csv=data_folder+"au_test_classifier_results.csv",
+		output_file_name=data_folder+"au_test_classification.csv",
+	run:
+		from scripts.random_forest_classifier import random_forest_classification
+		try:
+			random_forest_classification(params.column_to_predict, input.combined_statistics,
+			output.output_file_name, output.model_features_file, output.classifier_metrics_csv,
+			params.parameter_file, params.data_folder)
+		except ValueError as e:
+			print(e)
 
 
 # plot signinficant instability prediction results
 rule plot_au_test_classifier:
-    input:
-        data_folder+"au_test_classifier.done",
-        all_au_test_results=data_folder+"au_test_result.csv",
-    output:
-        temp(touch("plot_au_test_classifier.done")),
-        pie_plot_file=data_folder+plots_folder+"au_pie_chart.pdf",
-    script:
-        "scripts/plot_au_test_classifier.py"
+	input:
+		data_folder+"au_test_classifier.done",
+		all_au_test_results=data_folder+"au_test_result.csv",
+	output:
+		touch("plot_au_test_classifier.done"),
+		pie_plot_file=data_folder+plots_folder+"au_pie_chart.pdf",
+	script:
+		"scripts/plot_au_test_classifier.py"
 
-#rule write_pruned_and_inferred_sitelh_files:
-#    input:
-#        reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
-#        trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
-#        full_model="{subdir}/iqtree-model.txt",
-#    output:
-#        touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
-#    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
-#    shell:
-#        """
-#        iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_ -m $(cat {input.full_model}) -n 0 -wsl
-#        iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_ -m $(cat {input.full_model}) -n 0 -wsl
-#        """
+rule write_pruned_and_inferred_sitelh_files:
+   input:
+       reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
+       trees="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.nwk",
+       full_model="{subdir}/iqtree-model.txt",
+   output:
+	   touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
+   benchmark:
+       touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
+   shell:
+       """
+       iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_ -m $(cat {input.full_model}) -n 0 -wsl
+       iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_ -m $(cat {input.full_model}) -n 0 -wsl
+       """
 
 # combine sitelh files of pruned and inferred tree to one file for CONSEL
-#rule combine_sitelh_files:
-#    input:
-#        full_tree_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_pruned_reduced_alignment.sitelh",
-#        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_inferred_reduced_alignment.sitelh",
-#    output:
-#        both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
-#    params:
-#        seq_id=lambda wildcards: wildcards.seq_id
-#    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_combine_sitelh_files{seq_id}.txt")
-#    script:
-#        "scripts/combine_sitelh_files.py"
+rule combine_sitelh_files:
+   input:
+       full_tree_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_pruned_reduced_alignment.sitelh",
+       inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_inferred_reduced_alignment.sitelh",
+   output:
+       both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
+   params:
+       seq_id=lambda wildcards: wildcards.seq_id
+   benchmark:
+       touch("{subdir}/benchmarking/benchmark_combine_sitelh_files{seq_id}.txt")
+   script:
+       "scripts/combine_sitelh_files.py"
 
 
 # run CONSEL to test model fit of full tree to reattached trees
-#rule consel_comparison:
-#    input:
-#        paup_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
-#    output:
-#        touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
-#    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_consel_comparison{seq_id}.txt"),
-#    shell:
-#        """
-#        {path_to_consel}/makermt --paup {input.paup_file}
-#        {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
-#        rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
-#        """
+rule consel_comparison:
+   input:
+       paup_file="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
+   output:
+       touch("{subdir}/reduced_alignments/{seq_id}/consel_test_model_fit.done"),
+   benchmark:
+       touch("{subdir}/benchmarking/benchmark_consel_comparison{seq_id}.txt"),
+   shell:
+       """
+       {path_to_consel}/makermt --paup {input.paup_file}
+       {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
+       rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
+       """
 
 
 # run pypythia to calculate difficulty on all MSAs
-#rule calculate_msa_difficulty:
-#    input:
-#         alignment_name="{subdir}/" + input_alignment
-#    output:
-#         output_file="{subdir}/pythia_difficulty.txt"
-#    benchmark:
-#        touch("{subdir}/benchmarking/benchmark_calculate_msa_difficulty.txt")
-#    shell:
-#        """
-#        pythia -m {input.alignment_name} -r {path_to_raxml} -o {output.output_file}/pythia_difficulty.txt
-#        """
+rule calculate_msa_difficulty:
+   input:
+        alignment_name="{subdir}/" + input_alignment
+   output:
+        output_file="{subdir}/pythia_difficulty.txt"
+   benchmark:
+       touch("{subdir}/benchmarking/benchmark_calculate_msa_difficulty.txt")
+   shell:
+       """
+       pythia -m {input.alignment_name} -r {path_to_raxml} -o {output.output_file}
+       """
+
+
+rule plot_msa_difficulty:
+   input:
+        alignment_name=expand("{subdir}/pythia_difficulty.txt", subdir=get_subdirs(data_folder))
+   output:
+        plot=data_folder+plots_folder+"pythia_difficulty.pdf"
+   benchmark:
+       touch("benchmarking/benchmark_plot_msa_difficulty.txt")
+   shell:
+       """
+       python scripts/plot_difficulties.py {data_folder} {output.plot} {data_folder}/pythia_difficulties.csv
+       """
+
 
 # create single file for each dataset with timing breakdowns for the rules
 rule combine_benchmark_outputs:
-    input:
-        "plot_au_test_classifier.done"
-    output:
-        output_file="{subdir}/benchmarking_data.csv"
-    params:
-        subdir=lambda wildcards: wildcards.subdir,
-        benchmarking_folder="{subdir}/benchmarking/",
-        output_plot_path="{subdir}/"+plots_folder
-    script:
-        "scripts/combine_benchmark_outputs.py"
+	input:
+		"plot_au_test_classifier.done"
+	output:
+		output_file="{subdir}/benchmarking_data.csv"
+	params:
+		subdir=lambda wildcards: wildcards.subdir,
+		benchmarking_folder="{subdir}/benchmarking/",
+		output_plot_path="{subdir}/"+plots_folder
+	script:
+		"scripts/combine_benchmark_outputs.py"
 
 
 # plot benchmarking results
 rule benchmark_outputs_across_datasets:
-    input:
-        dfs=expand("{subdir}/benchmarking_data.csv", subdir=get_subdirs(data_folder)),
-        fastas=expand("{subdir}/" + input_alignment, subdir=get_subdirs(data_folder))
-    output:
-        temp(touch("benchmarking_plots.done"))
-    params:
-        plots_folder = data_folder + "plots/"
-    script:
-        "scripts/benchmark_outputs_across_datasets.py"
+	input:
+		dfs=expand("{subdir}/benchmarking_data.csv", subdir=get_subdirs(data_folder)),
+		fastas=expand("{subdir}/" + input_alignment, subdir=get_subdirs(data_folder))
+	output:
+		temp(touch("benchmarking_plots.done"))
+	params:
+		plots_folder = data_folder + "plots/"
+	script:
+		"scripts/benchmark_outputs_across_datasets.py"

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -413,15 +413,15 @@ rule plot_au_test_classifier:
 #        touch("{subdir}/benchmarking/benchmark_write_pruned_and_inferred_sitelh_files{seq_id}.txt"),
 #    shell:
 #        """
-#        iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel- -m $(cat {input.full_model}) -n 0 -wsl
-#        iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel- -m $(cat {input.full_model}) -n 0 -wsl
+#        iqtree -s {input.reduced_msa} -z $(head -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_pruned_ -m $(cat {input.full_model}) -n 0 -wsl
+#        iqtree -s {input.reduced_msa} -z $(tail -1 {input.trees}) --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel_inferred_ -m $(cat {input.full_model}) -n 0 -wsl
 #        """
 
 # combine sitelh files of pruned and inferred tree to one file for CONSEL
 #rule combine_sitelh_files:
 #    input:
-#        full_tree_sitelh="{subdir}/consel-"+input_alignment+".sitelh"
-#        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel-reduced_alignment.sitelh",
+#        full_tree_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_pruned_reduced_alignment.sitelh",
+#        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel_inferred_reduced_alignment.sitelh",
 #    output:
 #        both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
 #    params:

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -111,7 +111,7 @@ rule run_iqtree_on_full_dataset:
         touch("{subdir}/benchmarking/benchmark_run_iqtree_on_full_dataset.txt")
     shell:
         """
-        iqtree -s {input.msa} -m $(cat {input.full_model}) -wsl --prefix {input.msa} -bb 1000 -redo
+        iqtree -s {input.msa} -m $(cat {input.full_model}) --prefix {input.msa} -bb 1000 -redo
         """
 
 
@@ -131,7 +131,7 @@ rule run_iqtree_restricted_alignments:
         touch("{subdir}/benchmarking/benchmark_run_iqtree_restricted_alignments_{seq_id}.txt")
     shell:
         """
-        iqtree -s {input.reduced_msa} -m $(cat {input.full_model}) -wsl --prefix {input.reduced_msa} -bb 1000 -redo
+        iqtree -s {input.reduced_msa} -m $(cat {input.full_model}) --prefix {input.reduced_msa} -bb 1000 -redo
         """
 
 
@@ -402,11 +402,40 @@ rule plot_au_test_classifier:
         "scripts/plot_au_test_classifier.py"
 
 
+#rule write_full_sitelh:
+#    input:
+#        full_msa="{subdir}/"+input_alignment,
+#        trees="{subdir}/"+input_alignment+".treefile",
+#        full_model="{subdir}/iqtree-model.txt",
+#    output:
+#        touch("{subdir}/write_full_sitelh.done"),
+#    benchmark:
+#        touch("{subdir}/benchmarking/benchmark_write_full_sitelh.txt"),
+#    shell:
+#        """
+#        iqtree -s {input.full_msa} -z {input.trees} --prefix {wildcards.subdir}/consel- -m $(cat {input.full_model}) -n 0 -wsl -redo
+#        """
+
+
+#rule write_inferred_sitelh:
+#    input:
+#        reduced_msa="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta",
+#        trees="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.fasta.treefile",
+#        full_model="{subdir}/iqtree-model.txt",
+#    output:
+#        touch("{subdir}/reduced_alignments/{seq_id}/write_inferred_sitelh.done"),
+#    benchmark:
+#        touch("{subdir}/benchmarking/benchmark_write_inferred_sitelh{seq_id}.txt"),
+#    shell:
+#        """
+#        iqtree -s {input.reduced_msa} -z {input.trees} --prefix {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/consel- -m $(cat {input.full_model}) -n 0 -wsl -redo
+#        """
+
 # combine sitelh files of pruned and inferred tree to one file for CONSEL
 #rule write_pruned_and_inferred_sitelh_files:
 #    input:
-#        full_tree_sitelh="{subdir}/"+input_alignment+".sitelh"
-#        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/reduced_alignment.sitelh",
+#        full_tree_sitelh="{subdir}/consel-"+input_alignment+".sitelh"
+#        inferred_trees_sitelh="{subdir}/reduced_alignments/{seq_id}/consel-reduced_alignment.sitelh",
 #    output:
 #        both_trees_txtfile="{subdir}/reduced_alignments/{seq_id}/pruned_and_inferred_tree.txt"
 #    params:
@@ -429,6 +458,7 @@ rule plot_au_test_classifier:
 #        """
 #        {path_to_consel}/makermt --paup {input.paup_file}
 #        {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
+#        rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
 #        """
 
 # create single file for each dataset with timing breakdowns for the rules

--- a/Analysis_snakefile
+++ b/Analysis_snakefile
@@ -372,7 +372,7 @@ rule analyse_au_test:
 # random forest classification for significant instability
 rule au_test_classifier:
 	input:
-		"analyse_au_test.done",
+		"all_consel_test_done.done",
 		combined_statistics=data_folder+"rf_regression_combined_statistics.csv",
 	params:
 		column_to_predict = "significant_unstable",
@@ -448,6 +448,40 @@ rule consel_comparison:
 	   {path_to_consel}/consel {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree
 	   rm {wildcards.subdir}/reduced_alignments/{wildcards.seq_id}/pruned_and_inferred_tree.rmt
 	   """
+
+# auxiliary function to check that all AU-tests are done
+def aggregate_all_consel_done(wildcards):
+	all_done = []
+	for subdir in subdirs:
+		fasta_files = glob.glob(os.path.join(subdir, "*.fasta"))
+		fasta_files = [os.readlink(file) if os.path.islink(file) else file for file in fasta_files]
+		seq_ids = get_seq_ids(fasta_files[0], "fasta")
+		for seq_id in seq_ids:
+			all_done.append(subdir+"/reduced_alignments/"+seq_id+"/consel_test_model_fit.done")
+	return all_done
+
+
+# rule that detects if all au test are done to then run rule analyse_au_test
+rule all_consel_test_done_subset:
+	input:
+		aggregate_all_consel_done
+	output:
+		touch("all_consel_test_done.done")
+
+
+# aggregate output of AU test and transform it to csv for classifier and plotting
+rule add_consel_to_au:
+	input:
+		"all_consel_test_done.done",
+		au_test_results=data_folder+"au_test_result.csv",
+	output:
+		temp(touch("all_consel_test_done.done")),
+	benchmark:
+		touch(data_folder + "benchmarking/benchmark_add_consel_to_au.txt")
+	params:
+		subdirs=subdirs
+	script:
+		"scripts/compare_au_outputs.py {data_folder} {input.au_test_results} {path_to_consel}"
 
 
 # run pypythia to calculate difficulty on all MSAs

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ cd consel/src; make; make install; make clean; cd ..
 -->
 The line defining `path_to_consel` in the file `config.yaml` should be updated to reflect the local build of CONSEL
 
-The [PyPythia utility](https://github.com/tschuelia/PyPythia) can be installed using conda. 
 It also requires a local build of [raxml-ng](https://github.com/amkozlov/raxml-ng), which is extensively documented. 
 <!-- To obtain on linux/unix:
 conda install -c conda-forge pypythia
 wget https://github.com/amkozlov/raxml-ng/releases/download/1.2.2/raxml-ng_v1.2.2_linux_x86_64.zip
 unzip raxml-ng_v1.2.2_linux_x86_64.zip
->
+
+update: pypythia is not included in environment.yml
+-->
 The line defining `path_to_raxml` in the file `config.yaml` should be updated to reflect the local build of RAxML
 
 ## Running the pipeline

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ tar -xvf cnsls020.tgz
 cd consel/src; make; make install; make clean; cd ..
 -->
 
-The [Pypythia utility](https://github.com/amkozlov/raxml-ng) contains extensive documentation for installing and running also.
+The [PyPythia utility](https://github.com/tschuelia/PyPythia) can be installed using conda. 
+It also requires a local build of [raxml-ng](https://github.com/amkozlov/raxml-ng) contains extensive documentation for installing and running also.
 <!-- To obtain on linux/unix:
+conda install -c conda-forge pypythia
 wget https://github.com/amkozlov/raxml-ng/releases/download/1.2.2/raxml-ng_v1.2.2_linux_x86_64.zip
 unzip raxml-ng_v1.2.2_linux_x86_64.zip
 >

--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ wget http://stat.sys.i.kyoto-u.ac.jp/prog/consel/pub/cnsls020.tgz
 tar -xvf cnsls020.tgz
 cd consel/src; make; make install; make clean; cd ..
 -->
+The line defining `path_to_consel` in the file `config.yaml` should be updated to reflect the local build of CONSEL
 
 The [PyPythia utility](https://github.com/tschuelia/PyPythia) can be installed using conda. 
-It also requires a local build of [raxml-ng](https://github.com/amkozlov/raxml-ng) contains extensive documentation for installing and running also.
+It also requires a local build of [raxml-ng](https://github.com/amkozlov/raxml-ng), which is extensively documented. 
 <!-- To obtain on linux/unix:
 conda install -c conda-forge pypythia
 wget https://github.com/amkozlov/raxml-ng/releases/download/1.2.2/raxml-ng_v1.2.2_linux_x86_64.zip
 unzip raxml-ng_v1.2.2_linux_x86_64.zip
 >
+The line defining `path_to_raxml` in the file `config.yaml` should be updated to reflect the local build of RAxML
 
 ## Running the pipeline
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This directory should contain subdirectories which themselves contain alignments
 Python packages that are required for running this pipeline can be found in `environment.yml`.
 A conda environment called *phylostability* for our analysis can be installed using `conda env create -f environment.yml`.
 
+The non-python utility [CONSEL](http://stat.sys.i.kyoto-u.ac.jp/prog/consel/) can be downloaded and installed separately using the instructions included on the homepage.
+<!-- To obtain on linux/unix:
+wget http://stat.sys.i.kyoto-u.ac.jp/prog/consel/pub/cnsls020.tgz 
+tar -xvf cnsls020.tgz
+cd consel/src; make; make install; make clean; cd ..
+-->
+
+The [Pypythia utility](https://github.com/amkozlov/raxml-ng) contains extensive documentation for installing and running also.
+<!-- To obtain on linux/unix:
+wget https://github.com/amkozlov/raxml-ng/releases/download/1.2.2/raxml-ng_v1.2.2_linux_x86_64.zip
+unzip raxml-ng_v1.2.2_linux_x86_64.zip
+>
 
 ## Running the pipeline
 

--- a/Subsampling_snakefile
+++ b/Subsampling_snakefile
@@ -3,6 +3,8 @@ import os
 data_folder = config["data_folder"]
 num_samples= config["num_samples"]
 
+if not os.path.exists(data_folder+"/selected_data/"):
+    os.makedirs(data_folder+"/selected_data/")
 
 rule all:
     input:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,5 @@
-data_folder: "harrington_data/selected_data"
+data_folder: "harrington_data"
 num_samples: 4
 num_cores: 10
-stability_measure : "normalised_tii"
 path_to_consel : "consel/bin"
-path_to_raxml : "./raxml-ng"
+path_to_raxml: "raxml-ng/raxml-ng"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
-data_folder: "fake_data"
+data_folder: "harrington_data/selected_data"
 num_samples: 4
 num_cores: 10
 stability_measure : "normalised_tii"
 path_to_consel : "consel/bin"
+path_to_raxml : "./raxml-ng"

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
-data_folder: "harrington_data"
+data_folder: "fake_data"
 num_samples: 4
 num_cores: 10
 stability_measure : "normalised_tii"
+path_to_consel : "consel/bin"

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - epa-ng
   - scikit-learn
   - optuna
+  - pypythia=1.1.4

--- a/scripts/calculate_difficulties.sh
+++ b/scripts/calculate_difficulties.sh
@@ -8,14 +8,16 @@ excluded_dirs="benchmarking normalised_tii plots rf_radius"
 for dir in $data_dir/*/; do
   latest_dir="${dir%/}"
   latest_dir="${latest_dir##*/}"
-  echo "$latest_dir: $listfound"
   listfound=$(echo $excluded_dirs | grep -w -q $latest_dir)
   if [ "$listfound" == "" ]; then
     if [ -f $dir/$alignment_name ]; then
+      echo "Alignment:"
+      echo $dir/$alignment_name
       if ! [ -f $dir/pythia_difficulty.txt ]; then
         echo "$(date): $dir"
         pythia -m $dir/$alignment_name -r $which_raxml -o $dir/pythia_difficulty.txt
       fi
     fi
   fi
+  touch $data_dir/"run_pythia.done"
 done

--- a/scripts/calculate_difficulties.sh
+++ b/scripts/calculate_difficulties.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+data_dir=$1 # e.g. "/path/to/harrington_data/selected_data"
+which_raxml=$2
+excluded_dirs="benchmarking normalised_tii plots rf_radius"
+
+for dir in $data_dir/*/; do
+  latest_dir="${dir%/}"
+  latest_dir="${latest_dir##*/}"
+  echo "$latest_dir: $listfound"
+  listfound=$(echo $excluded_dirs | grep -w -q $latest_dir)
+  if [ "$listfound" == "" ]; then
+    if [ -f $dir/full_alignment.fasta ]; then
+      pythia -m $dir/full_alignment.fasta -r $which_raxml -o $dir/pythia_difficulty.txt
+    fi
+  fi
+done

--- a/scripts/calculate_difficulties.sh
+++ b/scripts/calculate_difficulties.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 data_dir=$1 # e.g. "/path/to/harrington_data/selected_data"
-which_raxml=$2
+alignment_name=$2 # e.g. "full_alignment.fasta"
+which_raxml=$3 # e.g. /path/to/raxml-ng
 excluded_dirs="benchmarking normalised_tii plots rf_radius"
 
 for dir in $data_dir/*/; do
@@ -10,8 +11,11 @@ for dir in $data_dir/*/; do
   echo "$latest_dir: $listfound"
   listfound=$(echo $excluded_dirs | grep -w -q $latest_dir)
   if [ "$listfound" == "" ]; then
-    if [ -f $dir/full_alignment.fasta ]; then
-      pythia -m $dir/full_alignment.fasta -r $which_raxml -o $dir/pythia_difficulty.txt
+    if [ -f $dir/$alignment_name ]; then
+      if ! [ -f $dir/pythia_difficulty.txt ]; then
+        echo "$(date): $dir"
+        pythia -m $dir/$alignment_name -r $which_raxml -o $dir/pythia_difficulty.txt
+      fi
     fi
   fi
 done

--- a/scripts/combine_sitelh_files.py
+++ b/scripts/combine_sitelh_files.py
@@ -2,7 +2,7 @@ import sys
 import numpy as np
 
 f1 = snakemake.input.full_tree_sitelh
-f2 = snakemake.input.inferred_tree_sitelh
+f2 = snakemake.input.inferred_trees_sitelh
 output_filename = snakemake.output.both_trees_txtfile
 
 full_str = "Tree	-lnL	Site	-lnL\n"
@@ -10,13 +10,13 @@ with open(f1, "r") as f:
     lines = f.readlines()
     full_str += "\t".join(lines[0].split())+"\n"
     for site, val in enumerate(lines[1].split()[1:]):
-        full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+        full_str += "\t\t"+str(site + 1) + "\t" + f"{-float(val.strip()):.10f}" + "\n"
 
 with open(f2, "r") as f:
     lines = f.readlines()
     full_str += "2\t"+str(lines[0].split()[-1])+"\n"
     for site, val in enumerate(lines[1].split()[1:]):
-        full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+        full_str += "\t\t"+str(site + 1) + "\t" + f"{-float(val.strip()):.10f}" + "\n"
 
 with open(output_filename, "w") as f:
     f.write(full_str)

--- a/scripts/combine_sitelh_files.py
+++ b/scripts/combine_sitelh_files.py
@@ -1,0 +1,20 @@
+import sys
+import numpy as np
+
+f1 = snakemake.input.full_tree_sitelh
+f2 = snakemake.input.inferred_tree_sitelh
+output_filename = snakemake.output.both_trees_txtfile
+
+full_str = "Tree	-lnL	Site	-lnL\n"
+with open(f1, "r") as f:
+    lines = f.readlines()
+    full_str += "\t".join(lines[0].split())+"\n"
+    for site, val in enumerate(lines[1].split()[1:]):
+        full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+with open(f2, "r") as f:
+    lines = f.readlines()
+    full_str += "2\t"+str(lines[0].split()[-1])+"\n"
+    for site, val in enumerate(lines[1].split()[1:]):
+        full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+with open(output_filename, "w") as f:
+    f.write(full_str)

--- a/scripts/combine_sitelh_files.py
+++ b/scripts/combine_sitelh_files.py
@@ -11,10 +11,12 @@ with open(f1, "r") as f:
     full_str += "\t".join(lines[0].split())+"\n"
     for site, val in enumerate(lines[1].split()[1:]):
         full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+
 with open(f2, "r") as f:
     lines = f.readlines()
     full_str += "2\t"+str(lines[0].split()[-1])+"\n"
     for site, val in enumerate(lines[1].split()[1:]):
         full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+
 with open(output_filename, "w") as f:
     f.write(full_str)

--- a/scripts/compare_au_outputs.py
+++ b/scripts/compare_au_outputs.py
@@ -18,13 +18,11 @@ else:
 full_pv_df["consel-p-AU"] = -1.0
 
 def read_pv_from_file(fn, col_to_read=3):
-    print(fn)
     with open(fn, "r") as f: 
         return f.readlines()[3].split()[col_to_read].strip()
 
 for subdir in subdirs:
     ds_name = subdir.split("/")[-2]
-    #if all(os.path.isfile(t_p + "consel.pv") for t_p in glob.glob(subdir+"/reduced_alignments/*/")):
     for taxon_path in glob.glob(subdir+"/reduced_alignments/*/"):
         taxon_name = taxon_path.split("/")[-2]
         if os.path.isfile(taxon_path + "consel.pv"):
@@ -36,6 +34,8 @@ for subdir in subdirs:
 
             pv_output = float(read_pv_from_file(taxon_path+"consel_pv_output"))
             full_pv_df.loc[(full_pv_df["dataset"] == ds_name) & (full_pv_df["seq_id"] == taxon_name), "consel-p-AU"] = pv_output
+        else:
+            print("Error: " + ds_name + "/" + taxon_name)
 
 full_pv_df.to_csv(full_pv_file.split(".csv")[0] + "_with_consel_pv.csv")
 

--- a/scripts/compare_au_outputs.py
+++ b/scripts/compare_au_outputs.py
@@ -10,7 +10,8 @@ the_dir = sys.argv[1]
 full_pv_file = sys.argv[2] # e.g. au_test_result.csv
 path_to_consel = sys.argv[3] # e.g. consel/bin/
 
-subdirs = [x for x in glob.glob(the_dir+"/*/") if os.path.isfile(x + "full_alignment.fasta.consel.sitelh")]
+subdirs = [x for x in glob.glob(the_dir+"/*/") if os.path.isfile(x + "full_alignment.fasta")]
+
 if os.path.isfile(full_pv_file.split(".csv")[0]+"_with_consel_pv.csv"):
     full_pv_df = pd.read_csv(full_pv_file.split(".csv")[0] + "_with_consel_pv.csv", index_col=0)
 else:
@@ -27,12 +28,12 @@ def read_pv_from_file(fn, col_to_read=3):
 
 for subdir in subdirs:
     ds_name = subdir.split("/")[-2]
-    for taxon_path in glob.glob(subdir+"/reduced_alignments/*/"):
+    for taxon_path in glob.glob(subdir+"reduced_alignments/*/"):
         taxon_name = taxon_path.split("/")[-2]
-        if os.path.isfile(taxon_path + "consel.pv"):
+        consel_output = taxon_path + "pruned_and_inferred_tree.pv"
+        if os.path.isfile(consel_output):
             if not (os.path.isfile(taxon_path + "consel_pv_output")):
-                consel_output = taxon_path + "consel.pv"
-                os.system(path_to_consel + "catpv " \
+                os.system(path_to_consel + "/catpv " \
                           + consel_output \
                           + " | sed -r 's/#|//g' > " + taxon_path + "consel_pv_output")
 

--- a/scripts/compare_au_outputs.py
+++ b/scripts/compare_au_outputs.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import glob
+import math
+import pandas as pd
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+the_dir = sys.argv[1]
+full_pv_file = sys.argv[2] # e.g. au_test_result.csv
+path_to_consel = sys.argv[3] # e.g. consel/bin/
+
+subdirs = [x for x in glob.glob(the_dir+"/*/") if os.path.isfile(x + "full_alignment.fasta.consel.sitelh")]
+if os.path.isfile(full_pv_file.split(".csv")[0]+"_with_consel_pv.csv"):
+    full_pv_df = pd.read_csv(full_pv_file.split(".csv")[0] + "_with_consel_pv.csv", index_col=0)
+else:
+    full_pv_df = pd.read_csv(full_pv_file, index_col=0)
+full_pv_df["consel-p-AU"] = -1.0
+
+def read_pv_from_file(fn, col_to_read=3):
+    print(fn)
+    with open(fn, "r") as f: 
+        return f.readlines()[3].split()[col_to_read].strip()
+
+for subdir in subdirs:
+    ds_name = subdir.split("/")[-2]
+    #if all(os.path.isfile(t_p + "consel.pv") for t_p in glob.glob(subdir+"/reduced_alignments/*/")):
+    for taxon_path in glob.glob(subdir+"/reduced_alignments/*/"):
+        taxon_name = taxon_path.split("/")[-2]
+        if os.path.isfile(taxon_path + "consel.pv"):
+            if not (os.path.isfile(taxon_path + "consel_pv_output")):
+                consel_output = taxon_path + "consel.pv"
+                os.system(path_to_consel + "catpv " \
+                          + consel_output \
+                          + " | sed -r 's/#|//g' > " + taxon_path + "consel_pv_output")
+
+            pv_output = float(read_pv_from_file(taxon_path+"consel_pv_output"))
+            full_pv_df.loc[(full_pv_df["dataset"] == ds_name) & (full_pv_df["seq_id"] == taxon_name), "consel-p-AU"] = pv_output
+
+full_pv_df.to_csv(full_pv_file.split(".csv")[0] + "_with_consel_pv.csv")
+
+def custom_format(values):
+    min_value = min(values)
+    new_values = []
+    for value in values:
+        if value == 0:
+            new_values.append("0%")
+        else:
+            decimal_places = abs(int(math.floor(math.log10(abs(value))))) 
+            if decimal_places < 2:
+                decimal_places = 2
+            format_string = "{{:.{}f}}%".format(decimal_places)
+            new_values.append(format_string.format(value))
+    return new_values
+
+df = full_pv_df.loc[full_pv_df["consel-p-AU"] >= 0]
+
+condition1 = ((df["normalised_tii"] == 0.0).sum())
+condition2 = ((df["normalised_tii"] > 0.0) & (df["consel-p-AU"] < 0.05)).sum()
+condition3 = ((df["normalised_tii"] > 0.0) & (df["consel-p-AU"] >= 0.05)).sum()
+sizes = [condition1, condition2, condition3]
+total = sum(sizes)
+percentages = custom_format([100 * (size / total) for size in sizes])
+labels = [
+    "stable ({}) \n".format(percentages[0]),
+    "unstable & significant ({}) \n".format(percentages[1]),
+    "unstable & non-significant ({}) \n".format(percentages[2]),
+]
+dark2 = mpl.colormaps["Dark2"]
+colors = [dark2.colors[i] for i in [2,1,0]]
+plt.figure(figsize=(12, 4))
+plt.pie(sizes, labels=labels, colors=colors, startangle=140)
+plt.axis("equal")
+plt.savefig("consel-p-AU-pie.png")
+
+plt.clf()
+
+full_pv_df.loc[:, ["p-AU", "consel-p-AU"]].plot.hist(alpha=0.5)
+plt.savefig("p-value-comparisons.png")
+
+plt.clf()
+
+full_pv_df.loc[full_pv_df["consel-p-AU"] >= 0, ["p-AU", "consel-p-AU"]].plot.hist(alpha=0.5)
+plt.savefig("nonmissing-p-value-comparisons.png")

--- a/scripts/compare_au_outputs.py
+++ b/scripts/compare_au_outputs.py
@@ -19,7 +19,11 @@ full_pv_df["consel-p-AU"] = -1.0
 
 def read_pv_from_file(fn, col_to_read=3):
     with open(fn, "r") as f: 
-        return f.readlines()[3].split()[col_to_read].strip()
+        lines = f.readlines()
+        if lines[3].split()[1].strip() == "1":
+            return lines[3].split()[col_to_read].strip()
+        else:
+            return lines[4].split()[col_to_read].strip()
 
 for subdir in subdirs:
     ds_name = subdir.split("/")[-2]

--- a/scripts/compare_full_to_subset_difficulty.py
+++ b/scripts/compare_full_to_subset_difficulty.py
@@ -1,0 +1,51 @@
+import os
+import glob
+import sys
+import pandas as pd
+import numpy as np
+import random
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+num_bins = int(sys.argv[1])
+df_name = sys.argv[2]
+data_path = sys.argv[3]
+raxml_path = sys.argv[4]
+fasta_name = sys.argv[5]
+num_sets_to_sample_per_range = int(sys.argv[6])
+
+bins = np.linspace(0, 1, num_bins+1)
+difficulties = []
+
+df = pd.read_csv(df_name, index_col=0)
+
+for i in range(num_bins):
+    loval = bins[i]
+    hival = bins[i+1]
+    dsets_in_difficulty_range = df.loc[(df["difficulty"] >= loval) & (df["difficulty"] < hival), "name"].tolist()
+    chosen_dsets = random.choices(dsets_in_difficulty_range, k = num_sets_to_sample_per_range)
+    for dset in chosen_dsets:
+        full_path = data_path+"/"+dset+"/reduced_alignments/"
+        if not all(os.path.isfile(x+"/pythia_difficulty.txt") for x in glob.glob(full_path+"/*/")):
+            os.system("./calculate_difficulties.sh " \
+                      + full_path \
+                      + " " + fasta_name \
+                      + " " + raxml_path)
+        for removed_taxon in glob.glob(full_path+"/*/"):
+            with open(removed_taxon + "/pythia_difficulty.txt", "r") as f:
+                difficulty = float(f.readlines()[0].strip())
+                difficulties.append([difficulty, "reduced MSA", i])
+
+        with open(data_path+"/"+dset+"/pythia_difficulty.txt", "r") as f:
+            difficulty = float(f.readlines()[0].strip())
+            difficulties.append([difficulty, "full MSA", i])
+
+full_difficulties = pd.DataFrame(difficulties, columns=["difficulty", "MSA type", "bin"])
+sns.violinplot(full_difficulties, x="bin", y="difficulty", hue="MSA type")
+plt.savefig("subsets_difficulties_violinplot.png")
+plt.clf()
+
+sns.boxplot(full_difficulties, x="bin", y="difficulty", hue="MSA type")
+plt.savefig("subsets_difficulties_boxplot.png")
+plt.clf()
+

--- a/scripts/get_nexus_data.sh
+++ b/scripts/get_nexus_data.sh
@@ -16,7 +16,7 @@ shopt -s nocasematch
 # Loop through Nexus files
 for dir in "${directories[@]}"; do
     if [[ $dir =~ plots || $dir == selected_data || $dir == benchmarking ]]; then
-        echo "Skippind directory $dir"
+        echo "Skipping directory $dir"
         continue
     fi
     echo "Processing directory $dir"

--- a/scripts/plot_au_test_classifier.py
+++ b/scripts/plot_au_test_classifier.py
@@ -35,8 +35,8 @@ def plot_au_test_pie_chart(df, plot_filepath):
 
     # Pie Chart
     condition1 = ((df["normalised_tii"] == 0.0).sum())
-    condition2 = ((df["normalised_tii"] > 0.0) & (df["p-AU"] < 0.05)).sum()
-    condition3 = ((df["normalised_tii"] > 0.0) & (df["p-AU"] >= 0.05)).sum()
+    condition2 = ((df["normalised_tii"] > 0.0) & (df["consel-p-AU"] < 0.05)).sum()
+    condition3 = ((df["normalised_tii"] > 0.0) & (df["consel-p-AU"] >= 0.05)).sum()
 
     # Data to plot
     sizes = [condition1, condition2, condition3]

--- a/scripts/plot_difficulties.py
+++ b/scripts/plot_difficulties.py
@@ -12,7 +12,7 @@ msa_name = []
 msa_difficulty = []
 for subdir in glob.glob(main_dir+"/*/"):
     if os.path.isfile(subdir+"pythia_difficulty.txt"):
-        msa_name.append(subdir.split("/")[-1])
+        msa_name.append(subdir.split("/")[-2])
         with open(subdir+"pythia_difficulty.txt", "r") as f:
             msa_difficulty.append(float(f.readlines()[0].strip()))
 msa_difficulties = pd.DataFrame({"name":msa_name, "difficulty":msa_difficulty})

--- a/scripts/plot_difficulties.py
+++ b/scripts/plot_difficulties.py
@@ -33,7 +33,7 @@ bin_width = 0.02
 
 # Calculate bin edges, offset to center bins around integers
 min_bin = min(msa_difficulty) - (min(msa_difficulty) % bin_width) - (bin_width / 2)
-max_bin = max(msa_difficulty) + (bin_width - (max(msa_difficulty) % bin_width)) + (bin_width / 2)
+max_bin = max(msa_difficulty) + (bin_width - (max(msa_difficulty) % bin_width)) + (bin_width / 2) + 0.02
 bins = np.arange(min_bin, max_bin, bin_width)
 
 plt.figure()

--- a/scripts/plot_difficulties.py
+++ b/scripts/plot_difficulties.py
@@ -1,0 +1,25 @@
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import glob
+import os
+
+main_dir = sys.argv[1]
+plot_path = sys.argv[2]
+csv_path = sys.argv[3]
+msa_name = []
+msa_difficulty = []
+for subdir in glob.glob(main_dir+"/*/"):
+    if os.path.isfile(subdir+"pythia_difficulty.txt"):
+        msa_name.append(subdir.split("/")[-1])
+        with open(subdir+"pythia_difficulty.txt", "r") as f:
+            msa_difficulty.append(float(f.readlines()[0].strip()))
+msa_difficulties = pd.DataFrame({"name":msa_name, "difficulty":msa_difficulty})
+msa_difficulties.to_csv(csv_path)
+
+plt.figure()
+sns.histplot(data=msa_difficulties, x="difficulty")
+plt.title("difficulty breakdown for selected MSA sets")
+plt.savefig(plot_path)
+plt.clf()

--- a/scripts/plot_difficulties.py
+++ b/scripts/plot_difficulties.py
@@ -1,9 +1,20 @@
 import sys
 import pandas as pd
+import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 import seaborn as sns
 import glob
 import os
+
+plt.rcParams.update({"font.size": 12})  # Adjust this value as needed
+plt.rcParams["axes.labelsize"] = 14
+plt.rcParams["axes.titlesize"] = 16
+plt.rcParams["xtick.labelsize"] = 12
+plt.rcParams["ytick.labelsize"] = 12
+
+# Colour for plots
+dark2 = mpl.colormaps["Dark2"]
 
 main_dir = sys.argv[1]
 plot_path = sys.argv[2]
@@ -18,8 +29,17 @@ for subdir in glob.glob(main_dir+"/*/"):
 msa_difficulties = pd.DataFrame({"name":msa_name, "difficulty":msa_difficulty})
 msa_difficulties.to_csv(csv_path)
 
+bin_width = 0.02
+
+# Calculate bin edges, offset to center bins around integers
+min_bin = min(msa_difficulty) - (min(msa_difficulty) % bin_width) - (bin_width / 2)
+max_bin = max(msa_difficulty) + (bin_width - (max(msa_difficulty) % bin_width)) + (bin_width / 2)
+bins = np.arange(min_bin, max_bin, bin_width)
+
 plt.figure()
-sns.histplot(data=msa_difficulties, x="difficulty")
-plt.title("difficulty breakdown for selected MSA sets")
+sns.histplot(data=msa_difficulties, x="difficulty", color=dark2.colors[0], bins=bins)
+plt.xlabel("difficulty score")
+# plt.title("difficulty breakdown for selected MSA sets")
+plt.tight_layout()
 plt.savefig(plot_path)
 plt.clf()

--- a/scripts/random_forest_classifier.py
+++ b/scripts/random_forest_classifier.py
@@ -11,6 +11,7 @@ def random_forest_classification(
     import pandas as pd
     import numpy as np
     import json
+    import os
     from sklearn.model_selection import train_test_split, RandomizedSearchCV
     from sklearn.ensemble import RandomForestClassifier
     from sklearn.impute import SimpleImputer
@@ -25,12 +26,15 @@ def random_forest_classification(
         "rf_radius",
         "change_to_low_bootstrap_dist",
         "tii",
-        "bootstrap_mean",
-        "bootstrap_std",
+        # "bootstrap_mean",
+        # "bootstrap_std",
+        # "difficulty",
         "num_leaves",
     ]
 
-    def train_random_forest_classifier(df, column_name):
+    def train_random_forest_classifier(
+        df, column_name, parameter_file, classifier_metrics_csv, model_features_csv
+    ):
         X = df.drop(cols_to_drop, axis=1)
         y = df[column_name]
         X = X.drop([column_name], axis=1)
@@ -96,9 +100,16 @@ def random_forest_classification(
             f1 = f1_score(y_val, y_pred)
             return f1
 
-        study = optuna.create_study(direction="maximize")
-        study.optimize(objective, n_trials=200)
-        best_params = study.best_params
+        if os.path.exists(parameter_file):
+            # load best hparams, if file exists already
+            with open(parameter_file, "r") as f:
+                best_params = json.load(f)
+            print("Loaded best parameters:", best_params)
+        else:
+            study = optuna.create_study(direction="maximize")
+            study.optimize(objective, n_trials=200)
+            best_params = study.best_params
+
         with open(parameter_file, "w") as f:
             json.dump(best_params, f, indent=4)
 
@@ -280,15 +291,31 @@ def random_forest_classification(
         df = add_au_test_result(df, au_df, only_au)
         df.to_csv(data_folder + "au_test_combined_statistics.csv")
         if only_au:
-            model_result = train_random_forest_classifier(df, column_name="p-AU_binary")
+            model_result = train_random_forest_classifier(
+                df,
+                "p-AU_binary",
+                parameter_file,
+                classifier_metrics_csv,
+                model_features_csv,
+            )
         else:
             model_result = train_random_forest_classifier(
-                df, column_name="significant_unstable"
+                df,
+                "significant_unstable",
+                parameter_file,
+                classifier_metrics_csv,
+                model_features_csv,
             )
     else:  # classifying stability (TII=0 vs !=0)
         df[column_name + "_binary"] = [1 if x > 0 else 0 for x in df[column_name]]
         column_name = column_name + "_binary"
-        model_result = train_random_forest_classifier(df, column_name)
+        model_result = train_random_forest_classifier(
+            df,
+            column_name,
+            parameter_file,
+            classifier_metrics_csv,
+            model_features_csv,
+        )
 
     if not isinstance(model_result, pd.DataFrame):
         with open(output_csv, "w") as f:

--- a/scripts/random_forest_classifier.py
+++ b/scripts/random_forest_classifier.py
@@ -270,30 +270,30 @@ def random_forest_classification(
             """
             Add results from au_test in given file au_test_results to df containing all summary statistics
             """
-            au_df_subset = au_df[["seq_id", "dataset", "p-AU"]]
+            au_df_subset = au_df[["seq_id", "dataset", "consel-p-AU"]]
             df["seq_id"] = df["seq_id"].str.replace(r"\s+\d+$", "", regex=True)
             merged_df = pd.merge(df, au_df_subset, on=["seq_id", "dataset"], how="left")
             if only_au:
-                merged_df["p-AU_binary"] = merged_df["p-AU"].apply(
+                merged_df["consel-p-AU_binary"] = merged_df["consel-p-AU"].apply(
                     lambda x: 1 if float(x) < 0.05 else 0
                 )
             else:
                 merged_df["significant_unstable"] = np.where(
-                    (merged_df["p-AU"] < 0.05) & (merged_df["tii"] != 0), 1, 0
+                    (merged_df["consel-p-AU"] < 0.05) & (merged_df["tii"] != 0), 1, 0
                 )
-            merged_df.drop("p-AU", axis=1, inplace=True)
+            merged_df.drop("consel-p-AU", axis=1, inplace=True)
             df = merged_df
             return df
 
         only_au = False
-        au_test_results = data_folder + "au_test_result.csv"
+        au_test_results = data_folder + "au_test_result_with_consel_pv.csv"
         au_df = pd.read_csv(au_test_results)
         df = add_au_test_result(df, au_df, only_au)
         df.to_csv(data_folder + "au_test_combined_statistics.csv")
         if only_au:
             model_result = train_random_forest_classifier(
                 df,
-                "p-AU_binary",
+                "consel-p-AU_binary",
                 parameter_file,
                 classifier_metrics_csv,
                 model_features_csv,
@@ -310,11 +310,7 @@ def random_forest_classification(
         df[column_name + "_binary"] = [1 if x > 0 else 0 for x in df[column_name]]
         column_name = column_name + "_binary"
         model_result = train_random_forest_classifier(
-            df,
-            column_name,
-            parameter_file,
-            classifier_metrics_csv,
-            model_features_csv,
+            df, column_name, parameter_file, classifier_metrics_csv, model_features_csv
         )
 
     if not isinstance(model_result, pd.DataFrame):

--- a/scripts/random_forest_plots.py
+++ b/scripts/random_forest_plots.py
@@ -44,6 +44,7 @@ feature_name_dict = {
     "seq_and_tree_dist_ratio_std": "distance ratio SD",
     "seq_distance_ratios_closest_seq_mean": "ratio diff closest sequence mean",
     "seq_distance_ratios_closest_seq_std": "ratio diff closest sequence SD",
+    "difficulty": "pythia difficulty"
 }
 
 def plot_random_forest_regression_results(
@@ -96,12 +97,7 @@ def plot_random_forest_regression_results(
     plt.clf()
 
 
-def plot_random_forest_classifier_results(results_csv, roc_csv, plot_filepath):
-    df = (
-        pd.read_csv(results_csv)
-        .replace(to_replace=True, value="unstable")
-        .replace(to_replace=False, value="stable")
-    )
+def plot_random_forest_classifier_results(roc_csv, plot_filepath):
     roc_df = pd.read_csv(roc_csv)
     roc_auc = auc(roc_df["fpr"], roc_df["tpr"])
 
@@ -121,6 +117,7 @@ def plot_random_forest_classifier_results(results_csv, roc_csv, plot_filepath):
     plt.tight_layout()
     plt.savefig(plot_filepath)
     plt.clf()
+
 
 
 def plot_random_forest_model_features(model_features_csv, plot_filepath):
@@ -425,7 +422,7 @@ if not empty(classifier_results_csv):
         plots_folder, "random_forest_classifier_results.pdf"
     )
     plot_random_forest_classifier_results(
-        classifier_results_csv, classifier_metrics_csv, random_forest_plot_filepath
+        classifier_metrics_csv, random_forest_plot_filepath
     )
     print("Done plotting random forest classifier results.")
 else:
@@ -437,7 +434,7 @@ if not empty(au_test_classifier_results):
     print("Start plotting au test classifier results")
     filepath = os.path.join(plots_folder, "au_test_classifier_results.pdf")
     plot_random_forest_classifier_results(
-        au_test_classifier_results, au_test_classifier_metrics_csv, filepath
+        au_test_classifier_metrics_csv, filepath
     )
     print("Done plotting au test classifier results")
 else:
@@ -449,7 +446,9 @@ if not empty(au_test_features):
     plot_random_forest_model_features(au_test_features, plot_filepath)
 else:
     print("Couldn't create plots. No random forest prediction for AU-test results.")
+print("Done plotting AU test random classifier results")
 
+print("Start plotting feature importances.")
 random_forest_feature_plots_filepath = [
     os.path.join(plots_folder, "tii_random_forest_model_features.pdf"),
     os.path.join(plots_folder, "rf_radius_random_forest_model_features.pdf"),

--- a/scripts/random_forest_regression.py
+++ b/scripts/random_forest_regression.py
@@ -2,12 +2,14 @@ import optuna
 import pandas as pd
 import numpy as np
 import json
+import os
 
 from sklearn.model_selection import train_test_split, RandomizedSearchCV
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.metrics import mean_squared_error
 
+data_dir = snakemake.params.data_folder
 csvs = snakemake.input.csvs
 output_csv = snakemake.output.output_file_name
 model_features_csv = snakemake.output.model_features_file
@@ -28,8 +30,9 @@ cols_to_drop = [
     "normalised_tii",
     "rf_radius",
     "change_to_low_bootstrap_dist",
-    "bootstrap_mean",
-    "bootstrap_std",
+    # "bootstrap_mean",
+    # "bootstrap_std",
+    # "difficulty",
     "num_leaves",
 ]
 
@@ -80,13 +83,6 @@ def train_random_forest(
     # Transform the validation and test sets using the same statistics
     X_val_imputed = imputer.transform(X_val)
     X_test_imputed = imputer.transform(X_test)
-    # Convert the result back to a pandas DataFrame
-    X_train_imputed_df = pd.DataFrame(
-        X_train_imputed, columns=X_train.columns, index=X_train.index
-    )
-    X_test_imputed_df = pd.DataFrame(
-        X_test_imputed, columns=X_test.columns, index=X_test.index
-    )
 
     # Hyperparameter optimisation with optuna
     def objective(trial):
@@ -112,16 +108,23 @@ def train_random_forest(
             criterion=criterion,
             random_state=42,
         )
-        model.fit(X_val_imputed, y_val)
+        model.fit(X_train_imputed, y_train)
         y_pred = model.predict(X_val_imputed)
         mse = mean_squared_error(y_val, y_pred)
         return mse
 
-    study = optuna.create_study(direction="minimize")
-    study.optimize(objective, n_trials=200)
-    best_params = study.best_params
-    with open(parameter_file[index], "a") as f:
-        json.dump(best_params, f, indent=4)
+    if os.path.exists(parameter_file[index]):
+        print(parameter_file[index])
+        # load best hparams, if file exists already
+        with open(parameter_file[index], "r") as f:
+            best_params = json.load(f)
+        print("Loaded best parameters:", best_params)
+    else:
+        study = optuna.create_study(direction="minimize")
+        study.optimize(objective, n_trials=200)
+        best_params = study.best_params
+        with open(parameter_file[index], "w") as f:
+             json.dump(best_params, f, indent=4)
 
     fit_model = RandomForestRegressor(
         n_estimators=best_params["n_estimators"],
@@ -130,7 +133,7 @@ def train_random_forest(
         min_samples_leaf=best_params["min_samples_leaf"],
         max_features=best_params["max_features"],
         criterion=best_params["criterion"],
-        random_state=42,
+        # random_state=42,
     )
     fit_model.fit(X_train_imputed, y_train)
 
@@ -209,10 +212,41 @@ def balance_df_stability_measure(df, min_test_size, bin_file, index):
     return evenly_distributed_df
 
 
+def get_difficulty_df(data_dir):
+    # Add difficulty to df
+    # Directory containing all dataset directories
+
+    # Initialize lists to store dataset names and difficulty values
+    dataset_names = []
+    difficulty_values = []
+
+    # Iterate over each directory in the base directory
+    for dataset_name in os.listdir(data_dir):
+        dataset_path = os.path.join(data_dir, dataset_name)
+        # Check if it is a directory
+        if os.path.isdir(dataset_path):
+            # Construct the path to the pythia_difficulty.txt file
+            difficulty_file_path = os.path.join(dataset_path, 'pythia_difficulty.txt')
+            if os.path.isfile(difficulty_file_path):
+                # Read the float value from the file
+                with open(difficulty_file_path, 'r') as file:
+                    difficulty_value = float(file.read().strip())
+                    # Store the dataset name and difficulty value
+                    dataset_names.append(dataset_name)
+                    difficulty_values.append(difficulty_value)
+
+    # Create a pandas DataFrame
+    data = {'dataset': dataset_names, 'difficulty': difficulty_values}
+    difficulty_df = pd.DataFrame(data)
+    return difficulty_df
+
+
+balance_data = False
+df = combine_dfs(csvs, subdirs)
+difficulty_df = get_difficulty_df(data_dir)
+df = pd.merge(df, difficulty_df, on='dataset', how='left')
+df.to_csv(combined_csv_path)
 for index in [0, 1]:
-    balance_data = False
-    df = combine_dfs(csvs, subdirs)
-    df.to_csv(combined_csv_path)
     if balance_data:
         print("Use bins to get balanced subset for regression.")
         min_test_size = 200  # needs to be adjusted to data

--- a/scripts/run_consel_on_selected_datasets.py
+++ b/scripts/run_consel_on_selected_datasets.py
@@ -12,7 +12,11 @@ print("\n".join(subdirs))
 if len(sys.argv) > 3:
     subdir_list = sys.argv[3]
     subdirs = pd.read_csv(subdir_list, header=None)
-    subdirs = subdirs[0]
+    subdirs = [x + "/" for x in subdirs[0]]
+
+rerun = False
+if len(sys.argv) > 4:
+    rerun = True
 
 
 which_consel = path_to_consel + "/consel"
@@ -44,7 +48,7 @@ for subdir in subdirs:
         full_model = " ".join(f.readlines())
 
     # check we've re-run IQTree using the -wsl flag to get the site-wise likelihoods out
-    if not os.path.isfile(full_tree_sitelh): 
+    if rerun or (not os.path.isfile(full_tree_sitelh)):
         os.system("iqtree -s " + full_msa \
                   + " -z " + pruned_tree \
                   + " -m " + full_model \
@@ -56,10 +60,14 @@ for subdir in subdirs:
         reduced_fasta = taxon_path + "without_taxon.fasta"
         reduced_msa = taxon_path + "reduced_alignment.fasta"
         reduced_tree = reduced_msa + ".treefile"
+        if not (os.path.isfile(reduced_msa)):
+            reduced_msa = reduced_fasta
         inferred_tree_sitelh = reduced_msa + ".consel.sitelh"
+        if not (os.path.isfile(inferred_tree_sitelh)):
+            inferred_tree_sitelh = taxon_path + "reduced_alignment.fasta.consel.sitelh"
 
-        if not os.path.isfile(inferred_tree_sitelh): 
-            os.system("iqtree -s " + reduced_fasta \
+        if rerun or (not os.path.isfile(inferred_tree_sitelh)):
+            os.system("iqtree -s " + reduced_msa \
                       + " -z " + reduced_tree \
                       + " -m " + full_model \
                       + " -n 0 " \

--- a/scripts/run_consel_on_selected_datasets.py
+++ b/scripts/run_consel_on_selected_datasets.py
@@ -1,0 +1,71 @@
+import glob
+import os
+import sys
+import numpy as np
+import pandas as pd
+
+data_dir = sys.argv[1]
+path_to_consel = sys.argv[2]
+
+subdirs = [x.split("/")[-2] + "/" for x in glob.glob(data_dir+"/*/") if os.path.isdir(x + "reduced_alignments/")]
+print("\n".join(subdirs))
+if len(sys.argv) > 3:
+    subdir_list = sys.argv[3]
+    subdirs = pd.read_csv(subdir_list, header=None)
+    subdirs = subdirs[0]
+
+
+which_consel = path_to_consel + "/consel"
+which_makermt = path_to_consel + "/makermt"
+
+def combine_sitelh_files(f1, f2, output_filename):
+    full_str = "Tree	-lnL	Site	-lnL\n"
+    with open(f1, "r") as f:
+        lines = f.readlines()
+        full_str += "\t".join(lines[0].split())+"\n"
+        for site, val in enumerate(lines[1].split()[1:]):
+            full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+    with open(f2, "r") as f:
+        lines = f.readlines()
+        full_str += "2\t"+str(lines[0].split()[-1])+"\n"
+        for site, val in enumerate(lines[1].split()[1:]):
+            full_str += "\t\t"+str(site + 1) + "\t" + str(-float(val.strip())) + "\n"
+    with open(output_filename, "w") as f:
+        f.write(full_str)
+
+for subdir in subdirs:
+    full_path = data_dir+subdir
+    full_msa = full_path + "full_alignment.fasta"
+    full_tree_sitelh = full_msa + ".consel.sitelh"
+    pruned_tree = full_msa + ".treefile"
+
+    full_model_file = data_dir + subdir + "/iqtree-model.txt"
+    with open(full_model_file, "r") as f:
+        full_model = " ".join(f.readlines())
+
+    # check we've re-run IQTree using the -wsl flag to get the site-wise likelihoods out
+    if not os.path.isfile(full_tree_sitelh): 
+        os.system("iqtree -s " + full_msa \
+                  + " -z " + pruned_tree \
+                  + " -m " + full_model \
+                  + " -n 0 " \
+                  + " -wsl --prefix " + full_msa + ".consel")
+
+    for taxon_path in glob.glob(full_path+"/reduced_alignments/*/"):
+        taxon = taxon_path.split("/")[-2]
+        reduced_fasta = taxon_path + "without_taxon.fasta"
+        reduced_msa = taxon_path + "reduced_alignment.fasta"
+        reduced_tree = reduced_msa + ".treefile"
+        inferred_tree_sitelh = reduced_msa + ".consel.sitelh"
+
+        if not os.path.isfile(inferred_tree_sitelh): 
+            os.system("iqtree -s " + reduced_fasta \
+                      + " -z " + reduced_tree \
+                      + " -m " + full_model \
+                      + " -n 0 " \
+                      + " -wsl --prefix " + reduced_msa + ".consel")
+
+        combine_sitelh_files(full_tree_sitelh, inferred_tree_sitelh, taxon_path+"consel.txt")
+        os.system(which_makermt + " --paup " + taxon_path + "consel.txt")
+        os.system(which_consel + " " + taxon_path + "consel")
+

--- a/scripts/run_consel_on_selected_datasets.py
+++ b/scripts/run_consel_on_selected_datasets.py
@@ -60,7 +60,7 @@ for subdir in subdirs:
             inferred_tree_sitelh = taxon_path + "reduced_alignment.fasta.consel.sitelh"
 
         pruned_tree_base = taxon_path + "pruned_tree.nwk"
-        os.system("head -1 " + taxon_path + "pruned_and_inferred_tree.nwk > " + taxon_path + pruned_tree_base)
+        os.system("head -1 " + taxon_path + "pruned_and_inferred_tree.nwk > " + pruned_tree_base)
         if rerun or (not os.path.isfile(pruned_tree_base + ".consel.sitelh")):
             os.system("iqtree -s " + reduced_msa \
                       + " -z " + pruned_tree_base \

--- a/scripts/run_consel_on_selected_datasets.py
+++ b/scripts/run_consel_on_selected_datasets.py
@@ -8,7 +8,7 @@ data_dir = sys.argv[1]
 path_to_consel = sys.argv[2]
 
 subdirs = [x.split("/")[-2] + "/" for x in glob.glob(data_dir+"/*/") if os.path.isdir(x + "reduced_alignments/")]
-print("\n".join(subdirs))
+
 if len(sys.argv) > 3:
     subdir_list = sys.argv[3]
     subdirs = pd.read_csv(subdir_list, header=None)
@@ -48,13 +48,6 @@ for subdir in subdirs:
         full_model = " ".join(f.readlines())
 
     # check we've re-run IQTree using the -wsl flag to get the site-wise likelihoods out
-    if rerun or (not os.path.isfile(full_tree_sitelh)):
-        os.system("iqtree -s " + full_msa \
-                  + " -z " + pruned_tree \
-                  + " -m " + full_model \
-                  + " -n 0 " \
-                  + " -wsl --prefix " + full_msa + ".consel")
-
     for taxon_path in glob.glob(full_path+"/reduced_alignments/*/"):
         taxon = taxon_path.split("/")[-2]
         reduced_fasta = taxon_path + "without_taxon.fasta"
@@ -66,6 +59,15 @@ for subdir in subdirs:
         if not (os.path.isfile(inferred_tree_sitelh)):
             inferred_tree_sitelh = taxon_path + "reduced_alignment.fasta.consel.sitelh"
 
+        pruned_tree_base = taxon_path + "pruned_tree.nwk"
+        os.system("head -1 " + taxon_path + "pruned_and_inferred_tree.nwk > " + taxon_path + pruned_tree_base)
+        if rerun or (not os.path.isfile(pruned_tree_base + ".consel.sitelh")):
+            os.system("iqtree -s " + reduced_msa \
+                      + " -z " + pruned_tree_base \
+                      + " -m " + full_model \
+                      + " -n 0 " \
+                      + " -wsl --prefix " + pruned_tree_base + ".consel")
+
         if rerun or (not os.path.isfile(inferred_tree_sitelh)):
             os.system("iqtree -s " + reduced_msa \
                       + " -z " + reduced_tree \
@@ -73,7 +75,7 @@ for subdir in subdirs:
                       + " -n 0 " \
                       + " -wsl --prefix " + reduced_msa + ".consel")
 
-        combine_sitelh_files(full_tree_sitelh, inferred_tree_sitelh, taxon_path+"consel.txt")
+        combine_sitelh_files(pruned_tree_base + ".consel.sitelh", inferred_tree_sitelh, taxon_path+"consel.txt")
         os.system(which_makermt + " --paup " + taxon_path + "consel.txt")
         os.system(which_consel + " " + taxon_path + "consel")
 


### PR DESCRIPTION
In this PR we add the computation of pythia difficulties, plotting the results, and using them for random forest predictions.
Additionally, we compute AU-test p-values with CONSEL and use them as predictors for our random forests, replacing the p-values computed with IQ-TREE.

## Additions
- `scripts/calculate_difficulties.sh`: compute pythia difficulty scores
- `scripts/combine_sitelh_files.py`: write per-site likeilhoods for inferred and pruned tree to one file
- `scripts/compare_au_outputs.py`: combine IQ-Tree and AU-test p-values in one dataframe and plot differences
- `scripts/compare_full_to_subset_difficulty.py`: plot comparison of difficulty scores of full alignment and reduced alignment for some datasets
- `scripts/plot_difficulties.py`: Plot pythia difficulties of all full alignments in histogram
- `scripts/run_consel_on_selected_datasets.py`: compute AU-test p-values on full alignments with CONSEL

## Changes
- `Analysis_snakefile`: Add rules for computing pythia difficulty, computing site likelihoods for CONSEL, and running CONSEL + formatting
- `README`: Explain how to install pythia and consel
- `config.yaml`: Add paths to install of consel and pythia
- `Subsampling_snakefile`: Create the `selected_data` directory if it doesn't exist yet
- `environment.yaml`: add pythia 1.1.4
- `scripts/plot_au_test_classifier.py`: Use CONSEL AU-test output for plotting pie chart
- `scripts/random_forest_classifier.py`: save and load hyperparameters + use CONSEL AU-test results instead of IQ-TREE + add pythia difficulty as predictor
- `scripts/random_forest_plots.py`: cleaning up + add pythia difficulty to feature importance plot
- `scripts/random_forest_regression.py`: save and load hyperparameters + add pythia difficulty as predictor